### PR TITLE
[dart_lsc] Prepare for 1.0.0 version of sensors and package_info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.2
+
+* Prepare for 1.0.0 version of sensors and package_info. ([dart_lsc](http://github.com/amirh/dart_lsc))
+
 ## 0.10.1
 
 * Downgraded Flutter to stable channel on Travis CI and CircleCI builds to align with pub.dev health scoring.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 0.10.1
+version: 0.10.2
 homepage: https://github.com/larryaasen/upgrader
 
 environment:
@@ -21,7 +21,7 @@ dependencies:
   http: ^0.12.0
 
   # From Flutter Team: Provides an API for querying information about an application package.
-  package_info: ^0.4.0+3
+  package_info: '>=0.4.0+3 <2.0.0'
 
   # From Flutter Team: Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android).
   shared_preferences: ^0.5.2


### PR DESCRIPTION
This should be a safe change, for more details see: https://github.com/flutter/flutter/wiki/Package-migration-to-1.0.0

This change was auto generated by [dart_lsc](https://github.com/amirh/dart_lsc).