### PR TITLE
Provide language localization in English and Spanish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ ios/Flutter/Generated.xcconfig
 ios/Runner/GeneratedPluginRegistrant.*
 .flutter-plugins-dependencies
 flutter_export_environment.sh
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.0
+
+* Major enhancements!
+* This update provides language localization in English and Spanish using the new class UpgraderMessage, with the ability to add additional languages, and customize strings. Support for Spanish is included and will work without code changes.
+* A few parameters were removed, and if used, will be a breaking change. Most use of this update will not require code changes.
+* Five parameters removed: buttonTitleIgnore, buttonTitleLater, buttonTitleUpdate, prompt, title.
+* All parameters that were removed are now contained in the messages parameter.
+* The body of the message can now be customized and uses mustache style template variables.
+* Bumped version to 2.0.0
+
 ## 0.11.2
 
 * Removed the restriction for Flutter SDK <1.18.0

--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ Flutter package for prompting users to upgrade when there is a newer version of 
 [![codecov](https://codecov.io/gh/larryaasen/upgrader/branch/master/graph/badge.svg)](https://codecov.io/gh/larryaasen/upgrader)
 [![pub package](https://img.shields.io/pub/v/upgrader.svg)](https://pub.dartlang.org/packages/upgrader)
 
-[Become a Patron!](https://www.patreon.com/bePatron?u=15315667)
-
 When a newer app version is availabe in the app store, a simple alert prompt widget or card is
 displayed. With today's modern app stores, there is little need to persuade users to upgrade
 because most of them are already using the auto upgrade feature. However, there may be times when
@@ -19,6 +17,8 @@ upgrading.
 
 The UI comes in two flavors: alert or card. The [UpgradeAlert](#alert-example) class is used to display the
 popup alert prompt, and the [UpgradeCard](#card-example) class is used to display the inline material design card.
+
+The text displayed in the upgrader package is localized in English and Spanish, and supports customization.
 
 ## Alert Example
 
@@ -76,19 +76,15 @@ The UpgradeAlert widget can be customized by setting parameters in the construct
 UpgradeAlert widget.
 
 * appcastConfig: the appcast configuration, defaults to ```null```
-* buttonTitleIgnore: the ignore button title, which defaults to ```Ignore```
-* buttonTitleLater: the later button title, which defaults to ```Later```
-* buttonTitleUpdate: the update button title, which defaults to ```Update Now```
 * client: an HTTP Client that can be replaced for mock testing, defaults to ```null```
 * daysUntilAlertAgain: days until alerting user again, which defaults to ```3```
 * debugDisplayAlways: always force the upgrade to be available, defaults to ```false```
 * debugDisplayOnce: display the upgrade at least once once, defaults to ```false```
 * debugLogging: display logging statements, which defaults to ```false```
-* onIgnore: Called when the ignore button is tapped, defaults to ```null```
-* onLater: Called when the later button is tapped, defaults to ```null```
-* onUpdate: Called when the update button is tapped, defaults to ```null```
-* prompt: the call to action message, which defaults to ```Would you like to update it now?```
-* title: the alert dialog title, which defaults to ```Update App?```
+* messages: optional localized messages used for display in upgrader
+* onIgnore: called when the ignore button is tapped, defaults to ```null```
+* onLater: called when the later button is tapped, defaults to ```null```
+* onUpdate: called when the update button is tapped, defaults to ```null```
 * showIgnore: hide or show Ignore button on dialog, which defaults to ```true```
 * showLater: hide or show Later button on dialog, which defaults to ```true```
 * canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by alert card)
@@ -174,6 +170,75 @@ Widget build(BuildContext context) {
 }
 ```
 
+## Customizing the display
+
+The strings displayed in upgrader can be customzied by extending the `UpgraderMessages` class
+to provide custom values.
+
+As an example, to replace the Ignore button with a custom value, first create a new
+class that extends UpgraderMessages, and override the buttonTitleIgnore function. Next,
+when calling UpgradeAlert (or UpgradeCard), add the paramter messages with an instance
+of your extended class. Here is an example:
+
+```dart
+class MyUpgraderMessages extends UpgraderMessages {
+  @override
+  String get buttonTitleIgnore => 'My Ignore';
+}
+
+UpgradeAlert(messages: MyUpgraderMessages());
+```
+
+## Language localization
+
+The strings displayed in upgrader are already localized in English and Spanish. New languages will be
+supported in the future with minor updates.
+
+The upgrader package can be supplied with additional languages in your code by extending the `UpgraderMessages` class
+to provide custom values.
+
+As an example, to add the Spanish (es) language (which is already provided), first create a new
+class that extends UpgraderMessages, and override the message function. Next, add a string for
+each of the messages. Finally, when calling UpgradeAlert (or UpgradeCard), add the paramter messages with an instance
+of your extended class. Here is an example:
+
+```dart
+class MySpanishMessages extends UpgraderMessages {
+  /// Override the message function to provide custom language localization.
+  @override
+  String message(UpgraderMessage messageKey) {
+    if (languageCode == 'es') {
+      switch (messageKey) {
+        case UpgraderMessage.body:
+          return 'es A new version of {{appName}} is available!';
+        case UpgraderMessage.buttonTitleIgnore:
+          return 'es Ignore';
+        case UpgraderMessage.buttonTitleLater:
+          return 'es Later';
+        case UpgraderMessage.buttonTitleUpdate:
+          return 'es Update Now';
+        case UpgraderMessage.prompt:
+          return 'es Want to update?';
+        case UpgraderMessage.title:
+          return 'es Update App?';
+      }
+    }
+    // Messages that are not provided above can still use the default values.
+    return super.message(messageKey);
+  }
+}
+
+UpgradeAlert(messages: MySpanishMessages());
+```
+
+You can even force the upgrade package to use a specific language, instead of the
+system language on the device. Just pass the language code to an instance of
+UpgraderMessages when displaying the alert or card. Here is an example:
+
+```dart
+UpgradeAlert(messages: UpgraderMessages(code: 'es'));
+```
+
 ## iTunes Search API
 
 There is a class in this Flutter package used by the upgrader widgets to download app details 
@@ -214,4 +279,7 @@ itunes_lookup all results:
 ## Contributing
 All [comments](https://github.com/larryaasen/upgrader/issues) and [pull requests](https://github.com/larryaasen/upgrader/pulls) are welcome.
 
-[Become a Patron!](https://www.patreon.com/bePatron?u=15315667)
+## Donations on Flattr
+
+[Please donate to the creator of upgrader!](https://flattr.com/@larryaasen)
+

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -12,6 +12,11 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>es</string>
+	</array>
 	<key>CFBundleName</key>
 	<string>upgrader_example</string>
 	<key>CFBundlePackageType</key>

--- a/example/lib/main-card.dart
+++ b/example/lib/main-card.dart
@@ -14,8 +14,13 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // Setup the Appcast for Android only. On iOS, the default behavior will be
-    // to use the App Store version of the app.
+    // Only call clearSavedSettings() during testing to reset internal values.
+    Upgrader().clearSavedSettings();
+
+    // On Android, setup the Appcast.
+    // On iOS, the default behavior will be to use the App Store version of
+    // the app, so update the Bundle Identifier in example/ios/Runner with a
+    // valid identifier already in the App Store.
     final appcastURL =
         'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
     final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
@@ -29,7 +34,10 @@ class MyApp extends StatelessWidget {
           body: Center(
               child: Container(
                   margin: EdgeInsets.fromLTRB(12.0, 0.0, 12.0, 0.0),
-                  child: UpgradeCard(appcastConfig: cfg)))),
+                  child: UpgradeCard(
+                    appcastConfig: cfg,
+                    debugLogging: true,
+                  )))),
     );
   }
 }

--- a/example/lib/main-localized.dart
+++ b/example/lib/main-localized.dart
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2020 Larry Aasen. All rights reserved.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show SynchronousFuture;
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:upgrader/upgrader.dart';
+
+void main() => runApp(Demo());
+
+class Demo extends StatelessWidget {
+  Demo({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      onGenerateTitle: (BuildContext context) =>
+          DemoLocalizations.of(context).title,
+      home: DemoApp(),
+      localizationsDelegates: [
+        const DemoLocalizationsDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: [
+        const Locale('en', ''), // English, no country code
+        const Locale('es', ''), // Spanish, no country code
+      ],
+    );
+  }
+}
+
+class DemoApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // Only call clearSavedSettings() during testing to reset internal values.
+    Upgrader().clearSavedSettings();
+
+    // On Android, setup the Appcast.
+    // On iOS, the default behavior will be to use the App Store version of
+    // the app, so update the Bundle Identifier in example/ios/Runner with a
+    // valid identifier already in the App Store.
+    final appcastURL =
+        'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
+    final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
+
+    return Scaffold(
+        appBar: AppBar(
+          title: Text(DemoLocalizations.of(context).title),
+        ),
+        body: UpgradeAlert(
+          appcastConfig: cfg,
+          debugLogging: true,
+          messages: MyUpgraderMessages(),
+          child: Center(child: Text(DemoLocalizations.of(context).checking)),
+        ));
+  }
+}
+
+class DemoLocalizations {
+  DemoLocalizations(this.locale);
+
+  final Locale locale;
+
+  static DemoLocalizations of(BuildContext context) {
+    return Localizations.of<DemoLocalizations>(context, DemoLocalizations);
+  }
+
+  static final Map<String, Map<String, String>> _localizedValues = {
+    'en': {
+      'checking': 'Checking...',
+      'title': 'Upgrader Localization Example',
+    },
+    'es': {
+      'checking': 'Comprobando...',
+      'title': 'Ejemplo Upgrader',
+    },
+  };
+
+  String get checking {
+    return _localizedValues[locale.languageCode]['checking'];
+  }
+
+  String get title {
+    return _localizedValues[locale.languageCode]['title'];
+  }
+}
+
+class DemoLocalizationsDelegate
+    extends LocalizationsDelegate<DemoLocalizations> {
+  const DemoLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) => ['en', 'es'].contains(locale.languageCode);
+
+  @override
+  Future<DemoLocalizations> load(Locale locale) {
+    return SynchronousFuture<DemoLocalizations>(DemoLocalizations(locale));
+  }
+
+  @override
+  bool shouldReload(DemoLocalizationsDelegate old) => false;
+}
+
+/// Extend the [UpgraderMessages] class to provide custom values.
+class MyUpgraderMessages extends UpgraderMessages {
+  /// Override the [buttonTitleIgnore] getter to provide a custom value. Values
+  /// provided in the [message] function will be used over this value.
+  @override
+  String get buttonTitleIgnore => 'My Ignore 1';
+
+  /// Override the message function to provide your own language localization.
+  @override
+  String message(UpgraderMessage messageKey) {
+    if (languageCode == 'es') {
+      switch (messageKey) {
+        case UpgraderMessage.body:
+          return 'es A new version of {{appName}} is available!';
+        case UpgraderMessage.buttonTitleIgnore:
+          return 'es Ignore';
+        case UpgraderMessage.buttonTitleLater:
+          return 'es Later';
+        case UpgraderMessage.buttonTitleUpdate:
+          return 'es Update Now';
+        case UpgraderMessage.prompt:
+          return 'es Want to update?';
+        case UpgraderMessage.title:
+          return 'es Update App?';
+      }
+    }
+    // Messages that are not provided above can still use the default values.
+    return super.message(messageKey);
+  }
+}

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -14,6 +14,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Only call clearSavedSettings() during testing to reset internal values.
     Upgrader().clearSavedSettings();
 
     // On Android, setup the Appcast.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,5 @@
 name: upgrader_example
 description: Demonstrates how to use the upgrader package.
-author: Larry Aasen <larryaasen@gmail.com>
 version: 1.0.0
 
 environment:
@@ -8,6 +7,8 @@ environment:
 
 dependencies:
   flutter:
+    sdk: flutter
+  flutter_localizations:
     sdk: flutter
   upgrader:
     path: ../

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -11,14 +11,8 @@ class _UpgradeBase extends StatefulWidget {
   /// The appcast configuration ([AppcastConfiguration]) used by [Appcast].
   final AppcastConfiguration appcastConfig;
 
-  /// The ignore button title, which defaults to ```Ignore```
-  final String buttonTitleIgnore;
-
-  /// The later button title, which defaults to ```Later```
-  final String buttonTitleLater;
-
-  /// The update button title, which defaults to ```Update Now```
-  final String buttonTitleUpdate;
+  /// The localized messages used for display in upgrader.
+  final UpgraderMessages messages;
 
   /// Days until alerting user again after later.
   final int daysToAlertAgain;
@@ -44,12 +38,6 @@ class _UpgradeBase extends StatefulWidget {
   /// Return false when the default behavior should not execute.
   final BoolCallback onUpdate;
 
-  /// The call to action message, which defaults to: Would you like to update it now?
-  final String prompt;
-
-  /// The title of the alert dialog. Defaults to: Update App?
-  final String title;
-
   /// Provide an HTTP Client that can be replaced for mock testing.
   final http.Client client;
 
@@ -65,9 +53,7 @@ class _UpgradeBase extends StatefulWidget {
   _UpgradeBase({
     Key key,
     this.appcastConfig,
-    this.buttonTitleIgnore,
-    this.buttonTitleLater,
-    this.buttonTitleUpdate,
+    this.messages,
     this.daysToAlertAgain = 3,
     this.debugDisplayAlways = false,
     this.debugDisplayOnce = false,
@@ -75,8 +61,6 @@ class _UpgradeBase extends StatefulWidget {
     this.onIgnore,
     this.onLater,
     this.onUpdate,
-    this.prompt,
-    this.title,
     this.client,
     this.showIgnore,
     this.showLater,
@@ -85,14 +69,8 @@ class _UpgradeBase extends StatefulWidget {
     if (appcastConfig != null) {
       Upgrader().appcastConfig = appcastConfig;
     }
-    if (buttonTitleIgnore != null) {
-      Upgrader().buttonTitleIgnore = buttonTitleIgnore;
-    }
-    if (buttonTitleLater != null) {
-      Upgrader().buttonTitleLater = buttonTitleLater;
-    }
-    if (buttonTitleUpdate != null) {
-      Upgrader().buttonTitleUpdate = buttonTitleUpdate;
+    if (messages != null) {
+      Upgrader().messages = messages;
     }
     if (client != null) {
       Upgrader().client = client;
@@ -117,12 +95,6 @@ class _UpgradeBase extends StatefulWidget {
     }
     if (onUpdate != null) {
       Upgrader().onUpdate = onUpdate;
-    }
-    if (prompt != null) {
-      Upgrader().prompt = prompt;
-    }
-    if (title != null) {
-      Upgrader().title = title;
     }
     if (showIgnore != null) {
       Upgrader().showIgnore = showIgnore;
@@ -170,9 +142,7 @@ class UpgradeCard extends _UpgradeBase {
     this.margin = const EdgeInsets.all(4.0),
     Key key,
     AppcastConfiguration appcastConfig,
-    String buttonTitleIgnore,
-    String buttonTitleLater,
-    String buttonTitleUpdate,
+    UpgraderMessages messages,
     int daysToAlertAgain,
     bool debugAlwaysUpgrade,
     bool debugDisplayOnce,
@@ -180,8 +150,6 @@ class UpgradeCard extends _UpgradeBase {
     BoolCallback onIgnore,
     BoolCallback onLater,
     BoolCallback onUpdate,
-    String prompt,
-    String title,
     http.Client client,
     bool showIgnore,
     bool showLater,
@@ -189,9 +157,7 @@ class UpgradeCard extends _UpgradeBase {
   }) : super(
             key: key,
             appcastConfig: appcastConfig,
-            buttonTitleIgnore: buttonTitleIgnore,
-            buttonTitleLater: buttonTitleLater,
-            buttonTitleUpdate: buttonTitleUpdate,
+            messages: messages,
             daysToAlertAgain: daysToAlertAgain,
             debugDisplayAlways: debugAlwaysUpgrade,
             debugDisplayOnce: debugDisplayOnce,
@@ -199,8 +165,6 @@ class UpgradeCard extends _UpgradeBase {
             onIgnore: onIgnore,
             onLater: onLater,
             onUpdate: onUpdate,
-            prompt: prompt,
-            title: title,
             client: client,
             showIgnore: showIgnore,
             showLater: showLater,
@@ -216,12 +180,14 @@ class UpgradeCard extends _UpgradeBase {
         future: Upgrader().initialize(),
         builder: (BuildContext context, AsyncSnapshot<bool> processed) {
           if (processed.connectionState == ConnectionState.done) {
+            assert(Upgrader().messages != null);
             if (Upgrader().shouldDisplayUpgrade()) {
               return Card(
                   color: Colors.white,
                   margin: margin,
                   child: _AlertStyleWidget(
-                      title: Text(Upgrader().title),
+                      title: Text(
+                          Upgrader().messages.message(UpgraderMessage.title)),
                       content: Column(
                         mainAxisSize: MainAxisSize.min,
                         mainAxisAlignment: MainAxisAlignment.start,
@@ -230,13 +196,17 @@ class UpgradeCard extends _UpgradeBase {
                           Text(Upgrader().message()),
                           Padding(
                               padding: EdgeInsets.only(top: 15.0),
-                              child: Text(Upgrader().prompt)),
+                              child: Text(Upgrader()
+                                  .messages
+                                  .message(UpgraderMessage.prompt))),
                         ],
                       ),
                       actions: <Widget>[
                         if (Upgrader().showIgnore)
                           FlatButton(
-                              child: Text(Upgrader().buttonTitleIgnore),
+                              child: Text(Upgrader()
+                                  .messages
+                                  .message(UpgraderMessage.buttonTitleIgnore)),
                               onPressed: () {
                                 // Save the date/time as the last time alerted.
                                 Upgrader().saveLastAlerted();
@@ -246,7 +216,9 @@ class UpgradeCard extends _UpgradeBase {
                               }),
                         if (Upgrader().showLater)
                           FlatButton(
-                              child: Text(Upgrader().buttonTitleLater),
+                              child: Text(Upgrader()
+                                  .messages
+                                  .message(UpgraderMessage.buttonTitleLater)),
                               onPressed: () {
                                 // Save the date/time as the last time alerted.
                                 Upgrader().saveLastAlerted();
@@ -255,7 +227,9 @@ class UpgradeCard extends _UpgradeBase {
                                 state.forceUpdateState();
                               }),
                         FlatButton(
-                            child: Text(Upgrader().buttonTitleUpdate),
+                            child: Text(Upgrader()
+                                .messages
+                                .message(UpgraderMessage.buttonTitleUpdate)),
                             onPressed: () {
                               // Save the date/time as the last time alerted.
                               Upgrader().saveLastAlerted();
@@ -279,9 +253,7 @@ class UpgradeAlert extends _UpgradeBase {
   UpgradeAlert({
     Key key,
     AppcastConfiguration appcastConfig,
-    String buttonTitleIgnore,
-    String buttonTitleLater,
-    String buttonTitleUpdate,
+    UpgraderMessages messages,
     this.child,
     int daysToAlertAgain,
     bool debugAlwaysUpgrade,
@@ -290,8 +262,6 @@ class UpgradeAlert extends _UpgradeBase {
     BoolCallback onIgnore,
     BoolCallback onLater,
     BoolCallback onUpdate,
-    String prompt,
-    String title,
     http.Client client,
     bool showIgnore,
     bool showLater,
@@ -299,9 +269,7 @@ class UpgradeAlert extends _UpgradeBase {
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
-          buttonTitleIgnore: buttonTitleIgnore,
-          buttonTitleLater: buttonTitleLater,
-          buttonTitleUpdate: buttonTitleUpdate,
+          messages: messages,
           daysToAlertAgain: daysToAlertAgain,
           debugDisplayAlways: debugAlwaysUpgrade,
           debugDisplayOnce: debugDisplayOnce,
@@ -309,8 +277,6 @@ class UpgradeAlert extends _UpgradeBase {
           onIgnore: onIgnore,
           onLater: onLater,
           onUpdate: onUpdate,
-          prompt: prompt,
-          title: title,
           client: client,
           showIgnore: showIgnore,
           showLater: showLater,

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2020 Larry Aasen. All rights reserved.
+ */
+
+import 'package:flutter/material.dart';
+
+/// The message identifiers used in upgrader.
+enum UpgraderMessage {
+  /// Body of the upgrade message
+  body,
+
+  /// Ignore button
+  buttonTitleIgnore,
+
+  /// Later button
+  buttonTitleLater,
+
+  /// Update Now button
+  buttonTitleUpdate,
+
+  /// Prompt message
+  prompt,
+
+  /// Title
+  title,
+}
+
+/// The default localized messages used for display in upgrader. Extend this
+/// class to provide custom values and new localizations for languages.
+/// An example to replace the Ignore button with a custom value would be:
+///
+/// ```dart
+/// class MyUpgraderMessages extends UpgraderMessages {
+///   @override
+///   String get buttonTitleIgnore => 'My Ignore';
+/// }
+///
+/// UpgradeAlert(messages: MyUpgraderMessages());
+/// ```
+///
+class UpgraderMessages {
+  /// The primary language subtag for the locale, which defaults to the
+  /// system-reported default locale of the device.
+  final String languageCode;
+
+  /// Provide a [code] to override the system-reported default locale.
+  UpgraderMessages({String code}) : languageCode = code ?? findLanguageCode();
+
+  /// Override the message function to provide custom language localization.
+  String message(UpgraderMessage messageKey) {
+    switch (messageKey) {
+      case UpgraderMessage.body:
+        return body;
+      case UpgraderMessage.buttonTitleIgnore:
+        return buttonTitleIgnore;
+      case UpgraderMessage.buttonTitleLater:
+        return buttonTitleLater;
+      case UpgraderMessage.buttonTitleUpdate:
+        return buttonTitleUpdate;
+      case UpgraderMessage.prompt:
+        return prompt;
+      case UpgraderMessage.title:
+        return title;
+      default:
+    }
+    return null;
+  }
+
+  /// Determine the current language code, either from the context, or
+  /// from the system-reported default locale of the device.
+  static String findLanguageCode({BuildContext context}) {
+    Locale locale;
+    if (context != null) {
+      locale = Localizations.localeOf(context, nullOk: true);
+    } else {
+      // Get the system locale
+      locale = WidgetsBinding.instance.window.locale;
+    }
+
+    return locale == null ? 'en' : locale.languageCode;
+  }
+
+  /// The body of the upgrade message. This string supports mustache style
+  /// template variables:
+  ///   {{appName}}
+  ///   {{currentAppStoreVersion}}
+  ///   {{currentInstalledVersion}}
+  /// Example:
+  ///  'A new version of Upgrader is available! Version 1.2 is now available-you have 1.0.';
+
+  /// Override this getter to provide a custom value. Values provided in the
+  /// [message] function will be used over this value.
+  String get body {
+    String message;
+    switch (languageCode) {
+      case 'en':
+        message =
+            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available-you have {{currentInstalledVersion}}.';
+        break;
+      case 'es':
+        message =
+            '¡Una nueva versión de {{appName}} está disponible! La versión {{currentAppStoreVersion}} ya está disponible-usted tiene {{currentInstalledVersion}}.';
+        break;
+    }
+    return message;
+  }
+
+  /// The ignore button title.
+  /// Override this getter to provide a custom value. Values provided in the
+  /// [message] function will be used over this value.
+  String get buttonTitleIgnore {
+    String message;
+    switch (languageCode) {
+      case 'en':
+        message = 'IGNORE';
+        break;
+      case 'es':
+        message = 'IGNORAR';
+        break;
+    }
+    return message;
+  }
+
+  /// The later button title.
+  /// Override this getter to provide a custom value. Values provided in the
+  /// [message] function will be used over this value.
+  String get buttonTitleLater {
+    String message;
+    switch (languageCode) {
+      case 'en':
+        message = 'LATER';
+        break;
+      case 'es':
+        message = 'MÁS TARDE';
+        break;
+    }
+    return message;
+  }
+
+  /// The update button title.
+  /// Override this getter to provide a custom value. Values provided in the
+  /// [message] function will be used over this value.
+  String get buttonTitleUpdate {
+    String message;
+    switch (languageCode) {
+      case 'en':
+        message = 'UPDATE NOW';
+        break;
+      case 'es':
+        message = 'ACTUALIZAR';
+        break;
+    }
+    return message;
+  }
+
+  /// The call to action prompt message.
+  /// Override this getter to provide a custom value. Values provided in the
+  /// [message] function will be used over this value.
+  String get prompt {
+    String message;
+    switch (languageCode) {
+      case 'en':
+        message = 'Would you like to update it now?';
+        break;
+      case 'es':
+        message = '¿Le gustaría actualizar ahora?';
+        break;
+    }
+    return message;
+  }
+
+  /// The alert dialog title.
+  /// Override this getter to provide a custom value. Values provided in the
+  /// [message] function will be used over this value.
+  String get title {
+    String message;
+    switch (languageCode) {
+      case 'en':
+        message = 'Update App?';
+        break;
+      case 'es':
+        message = '¿Actualizar la aplicación?';
+        break;
+    }
+    return message;
+  }
+}

--- a/lib/upgrader.dart
+++ b/lib/upgrader.dart
@@ -7,4 +7,5 @@ library upgrader;
 export 'src/appcast.dart';
 export 'src/itunes_search_api.dart';
 export 'src/upgrade_alert.dart';
+export 'src/upgrade_messages.dart';
 export 'src/upgrader.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 0.11.2
+version: 2.0.0
 homepage: https://github.com/larryaasen/upgrader
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: ">=2.2.2"
   flutter: ">=1.12.0"
 
 dependencies:

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -113,17 +113,17 @@ void main() {
     expect(upgrader.isUpdateAvailable(), true);
     expect(upgrader.isTooSoon(), false);
 
-    expect(upgrader.buttonTitleIgnore, 'IGNORE');
-    expect(upgrader.buttonTitleLater, 'LATER');
-    expect(upgrader.buttonTitleUpdate, 'UPDATE NOW');
+    expect(upgrader.messages, isNotNull);
 
-    upgrader.buttonTitleIgnore = 'aaa';
-    upgrader.buttonTitleLater = 'bbb';
-    upgrader.buttonTitleUpdate = 'ccc';
+    expect(upgrader.messages.buttonTitleIgnore, 'IGNORE');
+    expect(upgrader.messages.buttonTitleLater, 'LATER');
+    expect(upgrader.messages.buttonTitleUpdate, 'UPDATE NOW');
 
-    expect(upgrader.buttonTitleIgnore, 'aaa');
-    expect(upgrader.buttonTitleLater, 'bbb');
-    expect(upgrader.buttonTitleUpdate, 'ccc');
+    upgrader.messages = MyUpgraderMessages();
+
+    expect(upgrader.messages.buttonTitleIgnore, 'aaa');
+    expect(upgrader.messages.buttonTitleLater, 'bbb');
+    expect(upgrader.messages.buttonTitleUpdate, 'ccc');
 
     await tester.pumpWidget(_MyWidget());
 
@@ -136,19 +136,19 @@ void main() {
 
     expect(upgrader.isTooSoon(), true);
 
-    expect(find.text(upgrader.title), findsOneWidget);
+    expect(find.text(upgrader.messages.title), findsOneWidget);
     expect(find.text(upgrader.message()), findsOneWidget);
-    expect(find.text(upgrader.prompt), findsOneWidget);
+    expect(find.text(upgrader.messages.prompt), findsOneWidget);
     expect(find.byType(FlatButton), findsNWidgets(3));
-    expect(find.text(upgrader.buttonTitleIgnore), findsOneWidget);
-    expect(find.text(upgrader.buttonTitleLater), findsOneWidget);
-    expect(find.text(upgrader.buttonTitleUpdate), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);
 
-    await tester.tap(find.text(upgrader.buttonTitleUpdate));
+    await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.buttonTitleIgnore), findsNothing);
-    expect(find.text(upgrader.buttonTitleLater), findsNothing);
-    expect(find.text(upgrader.buttonTitleUpdate), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   });
@@ -189,9 +189,9 @@ void main() {
     await tester.pumpAndSettle();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.buttonTitleIgnore));
+    await tester.tap(find.text(upgrader.messages.buttonTitleIgnore));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   });
@@ -232,9 +232,9 @@ void main() {
     await tester.pumpAndSettle();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.buttonTitleLater));
+    await tester.tap(find.text(upgrader.messages.buttonTitleLater));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   });
@@ -252,6 +252,8 @@ void main() {
             version: '0.9.9',
             buildNumber: '400'));
     await upgrader.initialize();
+
+    expect(upgrader.messages, isNotNull);
 
     var called = false;
     var notCalled = true;
@@ -275,12 +277,12 @@ void main() {
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.buttonTitleUpdate));
+    await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();
 
     expect(called, true);
     expect(notCalled, true);
-    expect(find.text(upgrader.buttonTitleUpdate), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsNothing);
   });
 
   testWidgets('test UpgradeWidget Card ignore', (WidgetTester tester) async {
@@ -319,12 +321,12 @@ void main() {
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.buttonTitleIgnore));
+    await tester.tap(find.text(upgrader.messages.buttonTitleIgnore));
     await tester.pumpAndSettle();
 
     expect(called, true);
     expect(notCalled, true);
-    expect(find.text(upgrader.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
   });
 
   testWidgets('test UpgradeWidget Card later', (WidgetTester tester) async {
@@ -363,12 +365,12 @@ void main() {
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    await tester.tap(find.text(upgrader.buttonTitleLater));
+    await tester.tap(find.text(upgrader.messages.buttonTitleLater));
     await tester.pumpAndSettle();
 
     expect(called, true);
     expect(notCalled, true);
-    expect(find.text(upgrader.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
   });
 
   testWidgets('test UpgradeWidget unknown app', (WidgetTester tester) async {
@@ -407,7 +409,7 @@ void main() {
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
-    final laterButton = find.text(upgrader.buttonTitleLater);
+    final laterButton = find.text(upgrader.messages.buttonTitleLater);
     expect(laterButton, findsNothing);
 
     expect(called, false);
@@ -457,4 +459,13 @@ class _MyWidgetCard extends StatelessWidget {
       ),
     );
   }
+}
+
+class MyUpgraderMessages extends UpgraderMessages {
+  @override
+  String get buttonTitleIgnore => 'aaa';
+  @override
+  String get buttonTitleLater => 'bbb';
+  @override
+  String get buttonTitleUpdate => 'ccc';
 }


### PR DESCRIPTION
- This update provides language localization in English and Spanish using the new class UpgraderMessage, with the ability to add additional languages, and customize strings. Support for Spanish is included and will work without code changes.

- A few parameters were removed, and if used, will be a breaking change. Most use of this update will not require code changes.
- Five parameters removed: buttonTitleIgnore, buttonTitleLater, buttonTitleUpdate, prompt, title.
- All parameters that were removed are now contained in the messages parameter.
- The body of the message can now be customized and uses mustache style template variables.
- Bumped version to 2.0.0.
- Removed the restriction for Flutter SDK <1.18.0