### PR TITLE
Country code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 2.1.0
 
+* Added support for an optional minimum app version. If the installed version is below the minimum app version,
+the ignore and later buttons will be hidden. This is similar to the critical update attribute for Appcast.
 * The iOS App Store query will now default to the country code of the system locale,
 instead of `US`. This will help suggest upgrades to users from countries other than
 the US. The country code can be overriden with the optional `countryCode` parameter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0
+
+* The iOS App Store query will now default to the country code of the system locale,
+instead of `US`. This will help suggest upgrades to users from countries other than
+the US. The country code can be overriden with the optional `countryCode` parameter.
+
 ## 2.0.0
 
 * Major enhancements!

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ UpgradeAlert widget.
 * showIgnore: hide or show Ignore button on dialog, which defaults to ```true```
 * showLater: hide or show Later button on dialog, which defaults to ```true```
 * canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by alert card)
+* countryCode: the country code that will override the system locale. Optional. (iOS only)
 
 ## Limitations
 These widgets work on both Android and iOS. When running on iOS the App Store will provide the

--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ UpgradeAlert widget.
 * showIgnore: hide or show Ignore button on dialog, which defaults to ```true```
 * showLater: hide or show Later button on dialog, which defaults to ```true```
 * canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by alert card)
-* countryCode: the country code that will override the system locale. Optional. (iOS only)
+* countryCode: the country code that will override the system locale, which defaults to ```null``` (iOS only)
+* minAppVersion: the minimum app version supported by this app. Earlier versions of this app will be forced to update to the current version. Defaults to ```null```.
 
 ## Limitations
 These widgets work on both Android and iOS. When running on iOS the App Store will provide the

--- a/example/lib/main-min-app-version.dart
+++ b/example/lib/main-min-app-version.dart
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2019 Larry Aasen. All rights reserved.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:upgrader/upgrader.dart';
+
+void main() => runApp(MyApp());
+
+class MyApp extends StatelessWidget {
+  MyApp({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    // Only call clearSavedSettings() during testing to reset internal values.
+    Upgrader().clearSavedSettings();
+
+    // On Android, setup the Appcast.
+    // On iOS, the default behavior will be to use the App Store version of
+    // the app, so update the Bundle Identifier in example/ios/Runner with a
+    // valid identifier already in the App Store.
+    final appcastURL =
+        'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
+    final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
+
+    return MaterialApp(
+      title: 'Upgrader Example',
+      home: Scaffold(
+          appBar: AppBar(
+            title: Text('Upgrader Example'),
+          ),
+          body: UpgradeAlert(
+            appcastConfig: cfg,
+            debugLogging: true,
+            child: Center(child: Text('Checking...')),
+            minAppVersion: '1.1.0',
+          )),
+    );
+  }
+}

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -53,6 +53,10 @@ class _UpgradeBase extends StatefulWidget {
   /// The country code that will override the system locale. Optional. Used only for iOS.
   final String countryCode;
 
+  /// The minimum app version supported by this app. Earlier versions of this app
+  /// will be forced to update to the current version. Optional.
+  String minAppVersion;
+
   _UpgradeBase({
     Key key,
     this.appcastConfig,
@@ -69,6 +73,7 @@ class _UpgradeBase extends StatefulWidget {
     this.showLater,
     this.canDismissDialog,
     this.countryCode,
+    this.minAppVersion,
   }) : super(key: key) {
     if (appcastConfig != null) {
       Upgrader().appcastConfig = appcastConfig;
@@ -111,6 +116,9 @@ class _UpgradeBase extends StatefulWidget {
     }
     if (countryCode != null) {
       Upgrader().countryCode = countryCode;
+    }
+    if (minAppVersion != null) {
+      Upgrader().minAppVersion = minAppVersion;
     }
   }
 
@@ -162,6 +170,7 @@ class UpgradeCard extends _UpgradeBase {
     bool showLater,
     bool canDismissDialog,
     String countryCode,
+    String minAppVersion,
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
@@ -178,6 +187,7 @@ class UpgradeCard extends _UpgradeBase {
           showLater: showLater,
           canDismissDialog: canDismissDialog,
           countryCode: countryCode,
+          minAppVersion: minAppVersion,
         );
 
   @override
@@ -277,6 +287,7 @@ class UpgradeAlert extends _UpgradeBase {
     bool showLater,
     bool canDismissDialog,
     String countryCode,
+    String minAppVersion,
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
@@ -293,6 +304,7 @@ class UpgradeAlert extends _UpgradeBase {
           showLater: showLater,
           canDismissDialog: canDismissDialog,
           countryCode: countryCode,
+          minAppVersion: minAppVersion,
         );
 
   @override

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -55,7 +55,7 @@ class _UpgradeBase extends StatefulWidget {
 
   /// The minimum app version supported by this app. Earlier versions of this app
   /// will be forced to update to the current version. Optional.
-  String minAppVersion;
+  final String minAppVersion;
 
   _UpgradeBase({
     Key key,

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -50,6 +50,9 @@ class _UpgradeBase extends StatefulWidget {
   /// Can alert dialog be dismissed on tap outside of the alert dialog. Not used by alert card. (default: false)
   final bool canDismissDialog;
 
+  /// The country code that will override the system locale. Optional. Used only for iOS.
+  final String countryCode;
+
   _UpgradeBase({
     Key key,
     this.appcastConfig,
@@ -65,6 +68,7 @@ class _UpgradeBase extends StatefulWidget {
     this.showIgnore,
     this.showLater,
     this.canDismissDialog,
+    this.countryCode,
   }) : super(key: key) {
     if (appcastConfig != null) {
       Upgrader().appcastConfig = appcastConfig;
@@ -104,6 +108,9 @@ class _UpgradeBase extends StatefulWidget {
     }
     if (canDismissDialog != null) {
       Upgrader().canDismissDialog = canDismissDialog;
+    }
+    if (countryCode != null) {
+      Upgrader().countryCode = countryCode;
     }
   }
 
@@ -154,21 +161,24 @@ class UpgradeCard extends _UpgradeBase {
     bool showIgnore,
     bool showLater,
     bool canDismissDialog,
+    String countryCode,
   }) : super(
-            key: key,
-            appcastConfig: appcastConfig,
-            messages: messages,
-            daysToAlertAgain: daysToAlertAgain,
-            debugDisplayAlways: debugAlwaysUpgrade,
-            debugDisplayOnce: debugDisplayOnce,
-            debugLogging: debugLogging,
-            onIgnore: onIgnore,
-            onLater: onLater,
-            onUpdate: onUpdate,
-            client: client,
-            showIgnore: showIgnore,
-            showLater: showLater,
-            canDismissDialog: canDismissDialog);
+          key: key,
+          appcastConfig: appcastConfig,
+          messages: messages,
+          daysToAlertAgain: daysToAlertAgain,
+          debugDisplayAlways: debugAlwaysUpgrade,
+          debugDisplayOnce: debugDisplayOnce,
+          debugLogging: debugLogging,
+          onIgnore: onIgnore,
+          onLater: onLater,
+          onUpdate: onUpdate,
+          client: client,
+          showIgnore: showIgnore,
+          showLater: showLater,
+          canDismissDialog: canDismissDialog,
+          countryCode: countryCode,
+        );
 
   @override
   Widget build(BuildContext context, _UpgradeBaseState state) {
@@ -266,6 +276,7 @@ class UpgradeAlert extends _UpgradeBase {
     bool showIgnore,
     bool showLater,
     bool canDismissDialog,
+    String countryCode,
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
@@ -281,6 +292,7 @@ class UpgradeAlert extends _UpgradeBase {
           showIgnore: showIgnore,
           showLater: showLater,
           canDismissDialog: canDismissDialog,
+          countryCode: countryCode,
         );
 
   @override

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -76,8 +76,8 @@ class UpgraderMessages {
       // Get the system locale
       locale = WidgetsBinding.instance.window.locale;
     }
-
-    return locale == null ? 'en' : locale.languageCode;
+    final code = locale == null ? 'en' : locale.languageCode;
+    return code;
   }
 
   /// The body of the upgrade message. This string supports mustache style

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -82,10 +82,12 @@ class Upgrader {
   /// Can alert dialog be dismissed on tap outside of the alert dialog. Not used by alert card. (default: false)
   bool canDismissDialog = false;
 
+  /// The country code that will override the system locale. Optional. Used only for iOS.
+  String countryCode;
+
   bool _displayed = false;
   bool _initCalled = false;
   PackageInfo _packageInfo;
-  String _countryCode;
 
   String _installedVersion;
   String _appStoreVersion;
@@ -135,9 +137,6 @@ class Upgrader {
       }
     }
 
-    // Get the current locale of the device (TBD), defaulting to US.
-    _countryCode ??= 'US';
-
     await _updateVersionInfo();
 
     _installedVersion = _packageInfo.version;
@@ -183,9 +182,12 @@ class Upgrader {
         return false;
       }
 
+      // The  country code of the locale, defaulting to `US`.
+      final code = countryCode ?? findCountryCode();
+
       final iTunes = ITunesSearchAPI();
       iTunes.client = client;
-      final country = _countryCode;
+      final country = code;
       final response = await iTunes.lookupByBundleId(_packageInfo.packageName,
           country: country);
 
@@ -306,6 +308,24 @@ class Upgrader {
       }
     }
     return _updateAvailable != null;
+  }
+
+  /// Determine the current country code, either from the context, or
+  /// from the system-reported default locale of the device. The default
+  /// is `US`.
+  String findCountryCode({BuildContext context}) {
+    Locale locale;
+    if (context != null) {
+      locale = Localizations.localeOf(context, nullOk: true);
+    } else {
+      // Get the system locale
+      locale = WidgetsBinding.instance.window.locale;
+    }
+    final code = locale == null ? 'US' : locale.countryCode;
+    if (debugLogging) {
+      print('upgrader: countryCode: $code');
+    }
+    return code;
   }
 
   void _showDialog(

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -85,6 +85,10 @@ class Upgrader {
   /// The country code that will override the system locale. Optional. Used only for iOS.
   String countryCode;
 
+  /// The minimum app version supported by this app. Earlier versions of this app
+  /// will be forced to update to the current version. Optional.
+  String minAppVersion;
+
   bool _displayed = false;
   bool _initCalled = false;
   PackageInfo _packageInfo;
@@ -272,7 +276,29 @@ class Upgrader {
     if (isTooSoon() || alreadyIgnoredThisVersion() || !isUpdateAvailable()) {
       return false;
     }
+
+    // If installed version below minimum app version, disable ignore and later
+    if (belowMinAppVersion()) {
+      showIgnore = false;
+      showLater = false;
+    }
+
     return true;
+  }
+
+  /// Is installed version below minimum app version?
+  bool belowMinAppVersion() {
+    var rv = false;
+    if (minAppVersion != null) {
+      try {
+        final minVersion = Version.parse(minAppVersion);
+        final installedVersion = Version.parse(_installedVersion);
+        rv = installedVersion < minVersion;
+      } catch (e) {
+        print(e);
+      }
+    }
+    return rv;
   }
 
   bool isTooSoon() {

--- a/test/upgrade_messages_test.dart
+++ b/test/upgrade_messages_test.dart
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020 Larry Aasen. All rights reserved.
+ */
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:upgrader/upgrader.dart';
+
+void main() {
+  testWidgets('test UpgraderMessages context', (WidgetTester tester) async {
+    final messages = UpgraderMessages();
+    expect(messages, isNotNull);
+
+    var expectationMet = false;
+    var widget = Text('Tester');
+
+    await tester.pumpWidget(
+      StatefulBuilder(
+        builder: (BuildContext context, StateSetter setState) {
+          final code = UpgraderMessages.findLanguageCode(context: context);
+          expect(code, 'en');
+          expectationMet = true;
+          return MaterialApp(
+            home: Material(
+              child: Center(
+                child: widget,
+              ),
+            ),
+          );
+        },
+      ),
+    );
+
+    expect(find.byWidget(widget), findsOneWidget);
+    expect(expectationMet, isTrue);
+  });
+
+  testWidgets('test UpgraderMessages es', (WidgetTester tester) async {
+    final messages = UpgraderMessages(code: 'es');
+    expect(messages, isNotNull);
+    expect(messages.body,
+        '¡Una nueva versión de {{appName}} está disponible! La versión {{currentAppStoreVersion}} ya está disponible-usted tiene {{currentInstalledVersion}}.');
+    expect(messages.buttonTitleIgnore, 'IGNORAR');
+    expect(messages.buttonTitleLater, 'MÁS TARDE');
+    expect(messages.buttonTitleUpdate, 'ACTUALIZAR');
+    expect(messages.prompt, '¿Le gustaría actualizar ahora?');
+    expect(messages.title, '¿Actualizar la aplicación?');
+  });
+}

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -378,6 +378,7 @@ void main() {
     final upgrader = Upgrader();
     upgrader.client = client;
     upgrader.debugLogging = true;
+    upgrader.countryCode = 'IT';
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -373,6 +373,42 @@ void main() {
     expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
   });
 
+  testWidgets('test UpgradeWidget MinAppVersion', (WidgetTester tester) async {
+    final client = MockClient.setupMockClient();
+    final upgrader = Upgrader();
+    upgrader.client = client;
+    upgrader.debugLogging = true;
+    upgrader.minAppVersion = '1.0.0';
+
+    upgrader.installPackageInfo(
+        packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '0.9.9',
+            buildNumber: '400'));
+    await upgrader.initialize();
+
+    expect(upgrader.isTooSoon(), false);
+    upgrader.minAppVersion = '0.5.0';
+    expect(upgrader.belowMinAppVersion(), false);
+    upgrader.minAppVersion = '1.0.0';
+    expect(upgrader.belowMinAppVersion(), true);
+    upgrader.minAppVersion = null;
+    expect(upgrader.belowMinAppVersion(), false);
+    upgrader.minAppVersion = 'empty';
+    expect(upgrader.belowMinAppVersion(), false);
+    upgrader.minAppVersion = '1.0.0';
+
+    await tester.pumpWidget(_MyWidgetCard());
+
+    // Pump the UI so the upgrade card is displayed
+    await tester.pumpAndSettle(const Duration(milliseconds: 5000));
+
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);
+  });
+
   testWidgets('test UpgradeWidget unknown app', (WidgetTester tester) async {
     final client = MockClient.setupMockClient();
     final upgrader = Upgrader();


### PR DESCRIPTION
Added support for country code with the iOS App Store. Added UpgraderMessages tests. Added support for an optional minimum app version.