### PR TITLE
Prevent the dialog and card from being closed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,9 @@ os:
   - linux
 sudo: false
 branches:
+  # Build all branches
   only:
-  - master
+    - /.*/
 addons:
   apt:
     # Flutter depends on /usr/lib/x86_64-linux-gnu/libstdc++.so.6 version GLIBCXX_3.4.18

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -202,6 +202,9 @@ class UpgradeCard extends _UpgradeBase {
           if (processed.connectionState == ConnectionState.done) {
             assert(Upgrader().messages != null);
             if (Upgrader().shouldDisplayUpgrade()) {
+              if (Upgrader().debugLogging) {
+                print('UpgradeCard: will display');
+              }
               return Card(
                   color: Colors.white,
                   margin: margin,
@@ -258,6 +261,10 @@ class UpgradeCard extends _UpgradeBase {
                               state.forceUpdateState();
                             }),
                       ]));
+            } else {
+              if (Upgrader().debugLogging) {
+                print('UpgradeCard: will not display');
+              }
             }
           }
           return Container(width: 0.0, height: 0.0);

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -373,7 +373,7 @@ void main() {
     expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
   });
 
-  testWidgets('test UpgradeWidget MinAppVersion', (WidgetTester tester) async {
+  testWidgets('test upgrader minAppVersion', (WidgetTester tester) async {
     final client = MockClient.setupMockClient();
     final upgrader = Upgrader();
     upgrader.client = client;
@@ -451,6 +451,19 @@ void main() {
 
     expect(called, false);
     expect(notCalled, true);
+  });
+
+  test('test upgrader shouldDisplayUpgrade', () async {
+    final client = MockClient.setupMockClient();
+    final upgrader = Upgrader();
+    upgrader.client = client;
+    upgrader.debugLogging = true;
+
+    expect(upgrader.shouldDisplayUpgrade(), false);
+    upgrader.debugDisplayAlways = true;
+    expect(upgrader.shouldDisplayUpgrade(), true);
+    upgrader.debugDisplayAlways = false;
+    expect(upgrader.shouldDisplayUpgrade(), false);
   });
 }
 


### PR DESCRIPTION
This PR intends to prevent the dialog and card from being closed when in a blocked state.
This PR attempts to resolve issue https://github.com/larryaasen/upgrader/issues/40.