### PR TITLE
Bug critical

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -40,6 +40,9 @@ class Upgrader {
   /// When an appcast is configured for iOS, the iTunes lookup is not used.
   AppcastConfiguration appcastConfig;
 
+  /// Provide an Appcast that can be replaced for mock testing.
+  Appcast appCast;
+
   /// Provide an HTTP Client that can be replaced for mock testing.
   http.Client client = http.Client();
 
@@ -156,7 +159,7 @@ class Upgrader {
         print('upgrader: appcast is available for this platform');
       }
 
-      final appcast = Appcast(client: client);
+      final appcast = appCast ?? Appcast(client: client);
       await appcast.parseAppcastItemsFromUri(appcastConfig.url);
       if (debugLogging) {
         var count = appcast.items == null ? 0 : appcast.items.length;
@@ -273,9 +276,10 @@ class Upgrader {
   }
 
   bool shouldDisplayUpgrade() {
+    final isBlocked = blocked();
     // If installed version below minimum app version, or is a critical update,
     // disable ignore and later buttons.
-    if (blocked()) {
+    if (isBlocked) {
       showIgnore = false;
       showLater = false;
     }
@@ -285,7 +289,7 @@ class Upgrader {
     if (!isUpdateAvailable()) {
       return false;
     }
-    if (blocked()) {
+    if (isBlocked) {
       return true;
     }
     if (isTooSoon() || alreadyIgnoredThisVersion()) {

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -41,7 +41,7 @@ class Upgrader {
   AppcastConfiguration appcastConfig;
 
   /// Provide an Appcast that can be replaced for mock testing.
-  Appcast appCast;
+  Appcast appcast;
 
   /// Provide an HTTP Client that can be replaced for mock testing.
   http.Client client = http.Client();
@@ -159,7 +159,7 @@ class Upgrader {
         print('upgrader: appcast is available for this platform');
       }
 
-      final appcast = appCast ?? Appcast(client: client);
+      final appcast = this.appcast ?? Appcast(client: client);
       await appcast.parseAppcastItemsFromUri(appcastConfig.url);
       if (debugLogging) {
         var count = appcast.items == null ? 0 : appcast.items.length;

--- a/test/mock_appcast.dart
+++ b/test/mock_appcast.dart
@@ -1,0 +1,65 @@
+import 'dart:io';
+
+import 'package:http/src/client.dart';
+import 'package:mockito/mockito.dart';
+
+import 'package:upgrader/src/appcast.dart';
+import 'package:upgrader/src/upgrader.dart';
+import 'mockclient.dart';
+
+class MockAppcast extends Mock implements Appcast {}
+
+class FakeAppcast extends Fake implements Appcast {
+  int callCount = 0;
+
+  @override
+  AppcastItem bestItem() {
+    callCount++;
+
+    return AppcastItem(
+      versionString: '1.0.0',
+      fileURL: 'http://some.fakewebsite.com',
+      tags: [],
+    );
+  }
+
+  @override
+  Future<List<AppcastItem>> parseAppcastItemsFromFile(File file) async {
+    callCount++;
+
+    return [AppcastItem()];
+  }
+
+  @override
+  Future<List<AppcastItem>> parseAppcastItemsFromUri(String appCastURL) async {
+    callCount++;
+
+    return [AppcastItem()];
+  }
+
+  @override
+  List<AppcastItem> parseItemsFromXMLString(String xmlString) {
+    callCount++;
+
+    return [AppcastItem()];
+  }
+
+  AppcastConfiguration config =
+      AppcastConfiguration(url: 'http://some.fakewebsite.com', supportedOS: [
+    'linux',
+    'macos',
+    'windows',
+    'android',
+    'ios',
+    'fuchsia',
+  ]);
+
+  @override
+  Client client = MockClient();
+
+  @override
+  List<AppcastItem> items = [];
+
+  @override
+  String osVersionString = '';
+}

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -10,9 +10,8 @@ import 'package:package_info/package_info.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:upgrader/upgrader.dart';
 
+import 'mock_appcast.dart';
 import 'mockclient.dart';
-
-class MockAppCast extends Mock implements Appcast {}
 
 void main() {
   SharedPreferences preferences;
@@ -456,6 +455,30 @@ void main() {
     expect(notCalled, true);
   });
 
+  group('initialize', () {
+    test('should use fake Appcast', () async {
+      final fakeAppcast = FakeAppcast();
+      final client = MockClient.setupMockClient();
+      final upgrader = Upgrader()
+        ..client = client
+        ..appcastConfig = fakeAppcast.config
+        ..debugLogging = true
+        ..appcast = fakeAppcast
+        ..installPackageInfo(
+          packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '1.9.6',
+            buildNumber: '42',
+          ),
+        );
+
+      await upgrader.initialize();
+
+      expect(fakeAppcast.callCount, greaterThan(0));
+    });
+  });
+
   group('shouldDisplayUpgrade', () {
     test('should respect `debugDisplayAlways` property', () {
       final client = MockClient.setupMockClient();
@@ -492,7 +515,7 @@ void main() {
     });
 
     test('should be blocked when bestItem has critical update', () async {
-      final appcast = MockAppCast();
+      final appcast = MockAppcast();
       const version = '2.0.0';
 
       when(appcast.bestItem()).thenReturn(
@@ -505,7 +528,7 @@ void main() {
 
       final upgrader = Upgrader()
         ..client = MockClient.setupMockClient()
-        ..appCast = appcast
+        ..appcast = appcast
         ..debugLogging = true
         ..installPackageInfo(
           packageInfo: PackageInfo(


### PR DESCRIPTION
@larryaasen Great work on #43! I noticed there wasn't any specific tests around the new `blocked` functionality so I thought I'd add a few. 

### Suggested Changes

- Add property to `Upgrader` to allow mocking out `Appcast` for testing
- Abstract the 'blocked()' function call into a variable so we only call it once instead of twice
- Add a `group` to test the `shouldDisplayUpgrade` method verifying `blocked` functionality