### PR TITLE
Add Cupertino Dialog to Fit iOS Style

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info/package_info.dart';
@@ -381,6 +382,38 @@ class Upgrader {
       barrierDismissible: canDismissDialog,
       context: context,
       builder: (BuildContext context) {
+        if (Platform.isIOS) {
+          return CupertinoAlertDialog(
+            title: Text(title),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Text(message),
+                Padding(
+                    padding: EdgeInsets.only(top: 15.0),
+                    child: Text(messages.message(UpgraderMessage.prompt))),
+              ],
+            ),
+            actions: <Widget>[
+              if (showIgnore)
+                CupertinoDialogAction(
+                    child: Text(
+                        messages.message(UpgraderMessage.buttonTitleIgnore)),
+                    onPressed: () => onUserIgnored(context, true)),
+              if (showLater)
+                CupertinoDialogAction(
+                    child: Text(
+                        messages.message(UpgraderMessage.buttonTitleLater)),
+                    onPressed: () => onUserLater(context, true)),
+              CupertinoDialogAction(
+                  isDefaultAction: true,
+                  child:
+                      Text(messages.message(UpgraderMessage.buttonTitleUpdate)),
+                  onPressed: () => onUserUpdated(context, !blocked())),
+            ],
+          );
+        }
         return AlertDialog(
           title: Text(title),
           content: Column(


### PR DESCRIPTION
![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-15 at 11 06 55](https://user-images.githubusercontent.com/17075926/96068600-5dd61200-0ed7-11eb-9e46-7e27dae03de0.png)

![Simulator Screen Shot - iPhone 11 Pro Max - 2020-10-15 at 11 06 55](https://user-images.githubusercontent.com/17075926/96068852-e9e83980-0ed7-11eb-9016-b2f222071742.png)


I need this ios style dialog so I attach my code. but if you want to make this optional, then add an optional flag like `useIosStyle`.