### PR TITLE
Android Update Without Appcast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
   - flutter packages get
   - flutter analyze --no-pub --no-current-package ./lib ./test ./example
   - dartfmt -n --set-exit-if-changed ./lib ./test ./example || travis_terminate 1
-    - flutter test test/play_store_test.dart
+  - flutter test test/play_store_test.dart
   - flutter test --coverage --coverage-path=lcov.info
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ script:
   - flutter packages get
   - flutter analyze --no-pub --no-current-package ./lib ./test ./example
   - dartfmt -n --set-exit-if-changed ./lib ./test ./example || travis_terminate 1
+    - flutter test test/play_store_test.dart
   - flutter test --coverage --coverage-path=lcov.info
-  - flutter test test/play_store_test.dart
+
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ script:
   - flutter analyze --no-pub --no-current-package ./lib ./test ./example
   - dartfmt -n --set-exit-if-changed ./lib ./test ./example || travis_terminate 1
   - flutter test --coverage --coverage-path=lcov.info
+  - flutter test test/play_store_test.dart
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,8 @@ script:
   - flutter packages get
   - flutter analyze --no-pub --no-current-package ./lib ./test ./example
   - dartfmt -n --set-exit-if-changed ./lib ./test ./example || travis_terminate 1
-  - flutter test test/play_store_test.dart
   - flutter test --coverage --coverage-path=lcov.info
-
+  - flutter test test/play_store_test.dart
 after_success:
   - bash <(curl -s https://codecov.io/bash)
 

--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -6,18 +6,23 @@ import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:http/http.dart' as http;
 
-class PlayStroeSearchAPI {
+class PlayStoreSearchAPI {
   /// Play Store Search Api URL
   final String playStorePrefixURL = 'play.google.com';
 
+  /// Provide an HTTP Client that can be replaced for mock testing.
+  http.Client? client = http.Client();
+
   bool debugEnabled = false;
 
-  dynamic lookupById(String id) async {
+  /// Look up by id.
+  Future<Document?> lookupById(String id) async {
     if (id.isEmpty) {
       return null;
     }
 
     final url = lookupURLById(id)!;
+
     final response = await http.get(url);
 
     if (response.statusCode != 200) {
@@ -26,6 +31,7 @@ class PlayStroeSearchAPI {
     }
 
     final decodedResults = _decodeResults(response.body);
+
     return decodedResults;
   }
 

--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -23,7 +23,7 @@ class PlayStoreSearchAPI {
 
     final url = lookupURLById(id)!;
 
-    final response = await http.get(url);
+    final response = await http.get(Uri.parse(url));
 
     if (response.statusCode != 200) {
       print('Can\'t find an app in the Play Store with the id: $id');
@@ -32,14 +32,17 @@ class PlayStoreSearchAPI {
 
     final decodedResults = _decodeResults(response.body);
 
+    print(decodedResults);
+
     return decodedResults;
   }
 
-  Uri? lookupURLById(id) {
-    final uri =
-        Uri.https(playStorePrefixURL, '/store/apps/details', {'id': '$id'});
+  String? lookupURLById(id) {
+    final url =
+        Uri.https(playStorePrefixURL, '/store/apps/details', {'id': '$id'})
+            .toString();
 
-    return uri;
+    return url;
   }
 
   Document? _decodeResults(jsonResponse) {

--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -32,8 +32,6 @@ class PlayStoreSearchAPI {
 
     final decodedResults = _decodeResults(response.body);
 
-    print(decodedResults);
-
     return decodedResults;
   }
 

--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2021 William Kwabla. All rights reserved.
+ */
+
+import 'package:html/parser.dart' show parse;
+import 'package:http/http.dart' as http;
+
+class PlayStroeSearchApi {
+  /// Play Store Search Api URL
+  final String playStorePrefixURL = 'play.google.com';
+
+  /// Provide an HTTP Client that can be replaced for mock testing.
+  http.Client? client = http.Client();
+
+  bool debugEnabled = false;
+
+  /// Look up by id.
+  /// Example: look up Kotoko Express Android App:
+  /// ```lookupURLById('com.kotoko.express');```
+
+  dynamic lookupById(String id) async {
+    if (id.isEmpty) {
+      return null;
+    }
+
+    final url = lookupURLById(id)!;
+    final response = await http.get(url);
+
+    if (response.statusCode != 200) {
+      print('Can\'t find an app in the Play Store with the id: $id');
+      return null;
+    }
+
+    final decodedResults = decodeResults(response.body);
+    return decodedResults;
+  }
+
+  Uri? lookupURLById(id) {
+    final uri =
+        Uri.https(playStorePrefixURL, '/store/apps/details', {'id': '$id'});
+
+    return uri;
+  }
+
+  dynamic decodeResults(jsonResponse) {
+    if (jsonResponse.isNotEmpty) {
+      final decodedResults = parse(jsonResponse);
+
+      return decodedResults;
+    }
+    return null;
+  }
+}
+
+class PlayStoreResults {
+  /// Return field releaseNotes from Play Store results.
+  static String? releaseNotes(response) {
+    final sectionElements = response.getElementsByClassName('W4P4ne');
+    final releaseNotesElement = sectionElements.firstWhere(
+      (elm) => elm.querySelector('.wSaTQd')!.text == 'What\'s New',
+    );
+    final releaseNotes = releaseNotesElement
+        .querySelector('.PHBdkd')
+        ?.querySelector('.DWPxHb')
+        ?.text;
+
+    return releaseNotes;
+  }
+
+  /// Return field trackViewUrl from Play Store results.
+  static String? trackViewUrl(id) {
+    final uri =
+        Uri.https('play.google.com', '/store/apps/details', {'id': '$id'})
+            .toString();
+
+    return uri;
+  }
+
+  /// Return field version from Play Store results.
+  static String? version(response) {
+    final additionalInfoElements = response.getElementsByClassName('hAyfc');
+    final versionElement = additionalInfoElements.firstWhere(
+      (elm) => elm.querySelector('.BgcNfc')!.text == 'Current Version',
+    );
+
+    final storeVersion = versionElement.querySelector('.htlgb')!.text;
+
+    return storeVersion;
+  }
+}

--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -2,21 +2,15 @@
  * Copyright (c) 2021 William Kwabla. All rights reserved.
  */
 
+import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:http/http.dart' as http;
 
-class PlayStroeSearchApi {
+class PlayStroeSearchAPI {
   /// Play Store Search Api URL
   final String playStorePrefixURL = 'play.google.com';
 
-  /// Provide an HTTP Client that can be replaced for mock testing.
-  http.Client? client = http.Client();
-
   bool debugEnabled = false;
-
-  /// Look up by id.
-  /// Example: look up Kotoko Express Android App:
-  /// ```lookupURLById('com.kotoko.express');```
 
   dynamic lookupById(String id) async {
     if (id.isEmpty) {
@@ -31,7 +25,7 @@ class PlayStroeSearchApi {
       return null;
     }
 
-    final decodedResults = decodeResults(response.body);
+    final decodedResults = _decodeResults(response.body);
     return decodedResults;
   }
 
@@ -42,7 +36,7 @@ class PlayStroeSearchApi {
     return uri;
   }
 
-  dynamic decodeResults(jsonResponse) {
+  Document? _decodeResults(jsonResponse) {
     if (jsonResponse.isNotEmpty) {
       final decodedResults = parse(jsonResponse);
 

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -15,7 +15,7 @@ class UpgradeAlert extends UpgradeBase {
   UpgradeAlert({
     Key? key,
     AppcastConfiguration? appcastConfig,
-    String? androidId,
+    String? applicationId,
     UpgraderMessages? messages,
     this.child,
     bool? debugAlwaysUpgrade,
@@ -37,7 +37,7 @@ class UpgradeAlert extends UpgradeBase {
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
-          androidId: androidId,
+          applicationId: applicationId,
           messages: messages,
           debugDisplayAlways: debugAlwaysUpgrade,
           debugDisplayOnce: debugDisplayOnce,

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -15,6 +15,7 @@ class UpgradeAlert extends UpgradeBase {
   UpgradeAlert({
     Key? key,
     AppcastConfiguration? appcastConfig,
+    String? androidId,
     UpgraderMessages? messages,
     this.child,
     bool? debugAlwaysUpgrade,
@@ -36,6 +37,7 @@ class UpgradeAlert extends UpgradeBase {
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
+          androidId: androidId,
           messages: messages,
           debugDisplayAlways: debugAlwaysUpgrade,
           debugDisplayOnce: debugDisplayOnce,

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -98,6 +98,9 @@ class UpgradeBase extends StatefulWidget {
     if (appcastConfig != null) {
       Upgrader().appcastConfig = appcastConfig;
     }
+    if (androidId != null) {
+      Upgrader().androidId = androidId;
+    }
     if (messages != null) {
       Upgrader().messages = messages;
     }

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -14,7 +14,7 @@ class UpgradeBase extends StatefulWidget {
   /// An optional value that can override the default packageName when
   /// attempting to reach the Google Play Store. This is useful if your app has
   /// a different package name in the Play Store.
-  final String? androidId;
+  final String? applicationId;
 
   /// The localized messages used for display in upgrader.
   final UpgraderMessages? messages;
@@ -76,7 +76,7 @@ class UpgradeBase extends StatefulWidget {
   UpgradeBase({
     Key? key,
     this.appcastConfig,
-    this.androidId,
+    this.applicationId,
     this.messages,
     this.debugDisplayAlways = false,
     this.debugDisplayOnce = false,
@@ -98,8 +98,8 @@ class UpgradeBase extends StatefulWidget {
     if (appcastConfig != null) {
       Upgrader().appcastConfig = appcastConfig;
     }
-    if (androidId != null) {
-      Upgrader().androidId = androidId;
+    if (applicationId != null) {
+      Upgrader().applicationId = applicationId;
     }
     if (messages != null) {
       Upgrader().messages = messages;

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -11,6 +11,11 @@ class UpgradeBase extends StatefulWidget {
   /// The appcast configuration ([AppcastConfiguration]) used by [Appcast].
   final AppcastConfiguration? appcastConfig;
 
+  /// An optional value that can override the default packageName when
+  /// attempting to reach the Google Play Store. This is useful if your app has
+  /// a different package name in the Play Store.
+  final String? androidId;
+
   /// The localized messages used for display in upgrader.
   final UpgraderMessages? messages;
 
@@ -71,6 +76,7 @@ class UpgradeBase extends StatefulWidget {
   UpgradeBase({
     Key? key,
     this.appcastConfig,
+    this.androidId,
     this.messages,
     this.debugDisplayAlways = false,
     this.debugDisplayOnce = false,

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -19,7 +19,7 @@ class UpgradeCard extends UpgradeBase {
     this.margin = const EdgeInsets.all(4.0),
     Key? key,
     AppcastConfiguration? appcastConfig,
-    String? androidId,
+    String? applicationId,
     UpgraderMessages? messages,
     bool? debugAlwaysUpgrade,
     bool? debugDisplayOnce,
@@ -37,7 +37,7 @@ class UpgradeCard extends UpgradeBase {
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
-          androidId: androidId,
+          applicationId: applicationId,
           messages: messages,
           debugDisplayAlways: debugAlwaysUpgrade,
           debugDisplayOnce: debugDisplayOnce,

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -19,6 +19,7 @@ class UpgradeCard extends UpgradeBase {
     this.margin = const EdgeInsets.all(4.0),
     Key? key,
     AppcastConfiguration? appcastConfig,
+    String? androidId,
     UpgraderMessages? messages,
     bool? debugAlwaysUpgrade,
     bool? debugDisplayOnce,
@@ -36,6 +37,7 @@ class UpgradeCard extends UpgradeBase {
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
+          androidId: androidId,
           messages: messages,
           debugDisplayAlways: debugAlwaysUpgrade,
           debugDisplayOnce: debugDisplayOnce,

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -161,7 +161,7 @@ class UpgraderMessages {
       case 'en':
       default:
         message =
-            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available - you have {{currentInstalledVersion}}.';
+            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available-you have {{currentInstalledVersion}}.';
         break;
     }
     return message;

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -161,7 +161,7 @@ class UpgraderMessages {
       case 'en':
       default:
         message =
-            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available-you have {{currentInstalledVersion}}.';
+            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available - you have {{currentInstalledVersion}}.';
         break;
     }
     return message;

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -13,7 +13,6 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:upgrader/src/play_store_search_api.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:version/version.dart';
-// import 'package:html/parser.dart' show parse;
 
 import 'appcast.dart';
 import 'itunes_search_api.dart';
@@ -49,7 +48,7 @@ class Upgrader {
   /// An optional value that can override the default packageName when
   /// attempting to reach the Google Play Store. This is useful if your app has
   /// a different package name in the Play Store.
-  String? androidId;
+  String? applicationId;
 
   /// Provide an Appcast that can be replaced for mock testing.
   Appcast? appcast;
@@ -215,11 +214,6 @@ class Upgrader {
         _releaseNotes = bestItem.itemDescription;
       }
     } else {
-      // If this platform is not iOS, skip the iTunes lookup
-      if (Platform.isAndroid) {
-        return false;
-      }
-
       if (_packageInfo == null || _packageInfo!.packageName.isEmpty) {
         return false;
       }
@@ -230,6 +224,7 @@ class Upgrader {
         print('upgrader: countryCode: $code');
       }
 
+      // If this platform is not iOS, skip the iTunes lookup
       // Get android update without appcast
       if (Platform.isAndroid) {
         await _getAndroidStoreVersion();
@@ -253,9 +248,9 @@ class Upgrader {
 
   /// Android info is fetched by parsing the html of the app store page.
   Future<bool?> _getAndroidStoreVersion() async {
-    final id = androidId ?? _packageInfo!.packageName;
+    final id = applicationId ?? _packageInfo!.packageName;
 
-    final PlayStore = PlayStroeSearchApi();
+    final PlayStore = PlayStroeSearchAPI();
 
     final response = await (PlayStore.lookupById(id));
 

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -542,7 +542,10 @@ class Upgrader {
           ));
     }
     return AlertDialog(
-      title: Text(title),
+      title: Text(
+        title,
+        textAlign: TextAlign.center,
+      ),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -564,7 +567,7 @@ class Upgrader {
           TextButton(
               child: Text(messages!.message(UpgraderMessage.buttonTitleLater)!),
               onPressed: () => onUserLater(context, true)),
-        TextButton(
+        ElevatedButton(
             child: Text(messages!.message(UpgraderMessage.buttonTitleUpdate)!),
             onPressed: () => onUserUpdated(context, !blocked())),
       ],

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -250,7 +250,7 @@ class Upgrader {
   Future<bool?> _getAndroidStoreVersion() async {
     final id = applicationId ?? _packageInfo!.packageName;
 
-    final PlayStore = PlayStroeSearchAPI();
+    final PlayStore = PlayStoreSearchAPI();
 
     final response = await (PlayStore.lookupById(id));
 

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -10,13 +10,13 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:package_info/package_info.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:upgrader/src/play_store_search_api.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:version/version.dart';
 
 import 'appcast.dart';
 import 'itunes_search_api.dart';
 import 'upgrade_messages.dart';
+import 'package:upgrader/src/play_store_search_api.dart';
 
 /// Signature of callbacks that have no arguments and return bool.
 typedef BoolCallback = bool Function();
@@ -228,18 +228,18 @@ class Upgrader {
       // Get android update without appcast
       if (Platform.isAndroid) {
         await _getAndroidStoreVersion();
-      }
+      } else if (Platform.isIOS) {
+        final iTunes = ITunesSearchAPI();
+        iTunes.client = client;
+        final country = code;
+        final response = await (iTunes
+            .lookupByBundleId(_packageInfo!.packageName, country: country));
 
-      final iTunes = ITunesSearchAPI();
-      iTunes.client = client;
-      final country = code;
-      final response = await (iTunes.lookupByBundleId(_packageInfo!.packageName,
-          country: country));
-
-      if (response != null) {
-        _appStoreVersion ??= ITunesResults.version(response);
-        _appStoreListingURL ??= ITunesResults.trackViewUrl(response);
-        _releaseNotes ??= ITunesResults.releaseNotes(response);
+        if (response != null) {
+          _appStoreVersion ??= ITunesResults.version(response);
+          _appStoreListingURL ??= ITunesResults.trackViewUrl(response);
+          _releaseNotes ??= ITunesResults.releaseNotes(response);
+        }
       }
     }
 
@@ -250,9 +250,9 @@ class Upgrader {
   Future<bool?> _getAndroidStoreVersion() async {
     final id = applicationId ?? _packageInfo!.packageName;
 
-    final PlayStore = PlayStoreSearchAPI();
+    final playStore = PlayStoreSearchAPI();
 
-    final response = await (PlayStore.lookupById(id));
+    final response = await (playStore.lookupById(id));
 
     if (response != null) {
       _appStoreVersion ??= PlayStoreResults.version(response);

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -256,7 +256,6 @@ class Upgrader {
     final id = androidId ?? _packageInfo!.packageName;
 
     final PlayStore = PlayStroeSearchApi();
-    PlayStore.client = client;
 
     final response = await (PlayStore.lookupById(id));
 

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -542,10 +542,7 @@ class Upgrader {
           ));
     }
     return AlertDialog(
-      title: Text(
-        title,
-        textAlign: TextAlign.center,
-      ),
+      title: Text(title),
       content: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         mainAxisSize: MainAxisSize.min,
@@ -567,7 +564,7 @@ class Upgrader {
           TextButton(
               child: Text(messages!.message(UpgraderMessage.buttonTitleLater)!),
               onPressed: () => onUserLater(context, true)),
-        ElevatedButton(
+        TextButton(
             child: Text(messages!.message(UpgraderMessage.buttonTitleUpdate)!),
             onPressed: () => onUserUpdated(context, !blocked())),
       ],

--- a/lib/upgrader.dart
+++ b/lib/upgrader.dart
@@ -7,6 +7,7 @@ library upgrader;
 export 'src/alert_style_widget.dart';
 export 'src/appcast.dart';
 export 'src/itunes_search_api.dart';
+export 'src/play_store_search_api.dart';
 export 'src/upgrade_alert.dart';
 export 'src/upgrade_base.dart';
 export 'src/upgrade_card.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,9 @@ dependencies:
   # A dart library for parsing, traversing, querying, transforming and building XML documents.
   xml: ^5.0.2
 
+  # Pure Dart library for HTML5 parsing
+  html: ^0.15.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -39,5 +42,5 @@ dev_dependencies:
   # From Dart Team: Mock library for Dart inspired by Mockito.
   mockito: ^5.0.0
   pedantic: ^1.11.0
- 
+
 flutter:

--- a/test/mock_play_store_client.dart
+++ b/test/mock_play_store_client.dart
@@ -19,7 +19,7 @@ class MockPlayStoreSearchClient {
       final url = request.url.toString();
 
       // ignore: unrelated_type_equality_checks
-      if (url == PlayStroeSearchAPI().lookupById(id)) {
+      if (url == PlayStoreSearchAPI().lookupById(id)) {
         return http.Response(response, 200);
       }
 

--- a/test/mock_play_store_client.dart
+++ b/test/mock_play_store_client.dart
@@ -19,7 +19,7 @@ class MockPlayStoreSearchClient {
       final url = request.url.toString();
 
       // ignore: unrelated_type_equality_checks
-      if (url == PlayStroeSearchApi().lookupById(id)) {
+      if (url == PlayStroeSearchAPI().lookupById(id)) {
         return http.Response(response, 200);
       }
 

--- a/test/mock_play_store_client.dart
+++ b/test/mock_play_store_client.dart
@@ -18,8 +18,7 @@ class MockPlayStoreSearchClient {
 
       final url = request.url.toString();
 
-      // ignore: unrelated_type_equality_checks
-      if (url == PlayStoreSearchAPI().lookupById(id)) {
+      if (url == PlayStoreSearchAPI().lookupURLById(id)) {
         return http.Response(response, 200);
       }
 

--- a/test/mock_play_store_client.dart
+++ b/test/mock_play_store_client.dart
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2021 William Kwabla. All rights reserved.
+ */
+
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:upgrader/upgrader.dart';
+
+// Create a MockClient using the Mock class provided by the Mockito package.
+// We will create a new instances of this class in each test.
+class MockPlayStoreSearchClient {
+  static http.Client setupMockClient() {
+    var id = 'com.kotoko.express';
+
+    final client = MockClient((http.Request request) async {
+      final response =
+          '{"results": [{"version": "2.1.6", "id": "com.kotoko.express",  "releaseNotes": "Bug fixes and performance enhancements"}]}';
+
+      final url = request.url.toString();
+
+      // ignore: unrelated_type_equality_checks
+      if (url == PlayStroeSearchApi().lookupById(id)) {
+        return http.Response(response, 200);
+      }
+
+      return http.Response('', 400);
+    });
+
+    return client;
+  }
+}

--- a/test/play_store_test.dart
+++ b/test/play_store_test.dart
@@ -3,12 +3,15 @@
  */
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:html/dom.dart';
 import 'package:upgrader/upgrader.dart';
+
+import 'mock_play_store_client.dart';
 
 void main() {
   var applicationId = 'com.kotoko.express';
   test('testing PlayStoreSearchAPI properties', () async {
-    final playStore = PlayStroeSearchAPI();
+    final playStore = PlayStoreSearchAPI();
     expect(playStore.debugEnabled, equals(false));
     playStore.debugEnabled = true;
     expect(playStore.debugEnabled, equals(true));
@@ -21,9 +24,12 @@ void main() {
   });
 
   test('testing lookupById', () async {
-    final playStore = PlayStroeSearchAPI();
+    final client = MockPlayStoreSearchClient.setupMockClient();
+    final playStore = PlayStoreSearchAPI();
+    playStore.client = client;
 
     final response = await playStore.lookupById(applicationId);
+    expect(response, isInstanceOf<Document>());
 
     final results = response!;
     expect(results, isNotNull);

--- a/test/play_store_test.dart
+++ b/test/play_store_test.dart
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2019 Larry Aasen. All rights reserved.
+ */
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:upgrader/upgrader.dart';
+
+import 'mock_play_store_client.dart';
+
+void main() {
+  var androidId = 'com.kotoko.express';
+  test('testing PlayStoreSearchAPI properties', () async {
+    final playStore = PlayStroeSearchApi();
+    expect(playStore.debugEnabled, equals(false));
+    playStore.debugEnabled = true;
+    expect(playStore.debugEnabled, equals(true));
+    expect(playStore.playStorePrefixURL.length, greaterThan(0));
+
+    expect(
+        playStore.lookupURLById(androidId),
+        equals(Uri.https(
+            'play.google.com', '/store/apps/details', {'id': androidId})));
+  });
+
+  test('testing lookupById', () async {
+    final client = MockPlayStoreSearchClient.setupMockClient();
+    final playStore = PlayStroeSearchApi();
+    playStore.client = client;
+
+    final response = await playStore.lookupById(androidId);
+
+    final results = response!;
+    expect(results, isNotNull);
+
+    expect(PlayStoreResults.releaseNotes(response),
+        'Bug fixes and performance enhancements');
+    expect(
+        PlayStoreResults.trackViewUrl(androidId),
+        Uri.https('play.google.com', '/store/apps/details', {'id': androidId})
+            .toString());
+    expect(PlayStoreResults.version(response), '2.1.6');
+  }, skip: false);
+}

--- a/test/play_store_test.dart
+++ b/test/play_store_test.dart
@@ -19,8 +19,8 @@ void main() {
 
     expect(
         playStore.lookupURLById(applicationId),
-        equals(Uri.https(
-            'play.google.com', '/store/apps/details', {'id': applicationId})));
+        equals(
+            'https://play.google.com/store/apps/details?id=com.kotoko.express'));
   });
 
   test('testing lookupById', () async {

--- a/test/play_store_test.dart
+++ b/test/play_store_test.dart
@@ -5,29 +5,25 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:upgrader/upgrader.dart';
 
-import 'mock_play_store_client.dart';
-
 void main() {
-  var androidId = 'com.kotoko.express';
+  var applicationId = 'com.kotoko.express';
   test('testing PlayStoreSearchAPI properties', () async {
-    final playStore = PlayStroeSearchApi();
+    final playStore = PlayStroeSearchAPI();
     expect(playStore.debugEnabled, equals(false));
     playStore.debugEnabled = true;
     expect(playStore.debugEnabled, equals(true));
     expect(playStore.playStorePrefixURL.length, greaterThan(0));
 
     expect(
-        playStore.lookupURLById(androidId),
+        playStore.lookupURLById(applicationId),
         equals(Uri.https(
-            'play.google.com', '/store/apps/details', {'id': androidId})));
+            'play.google.com', '/store/apps/details', {'id': applicationId})));
   });
 
   test('testing lookupById', () async {
-    final client = MockPlayStoreSearchClient.setupMockClient();
-    final playStore = PlayStroeSearchApi();
-    playStore.client = client;
+    final playStore = PlayStroeSearchAPI();
 
-    final response = await playStore.lookupById(androidId);
+    final response = await playStore.lookupById(applicationId);
 
     final results = response!;
     expect(results, isNotNull);
@@ -35,8 +31,9 @@ void main() {
     expect(PlayStoreResults.releaseNotes(response),
         'Bug fixes and performance enhancements');
     expect(
-        PlayStoreResults.trackViewUrl(androidId),
-        Uri.https('play.google.com', '/store/apps/details', {'id': androidId})
+        PlayStoreResults.trackViewUrl(applicationId),
+        Uri.https(
+                'play.google.com', '/store/apps/details', {'id': applicationId})
             .toString());
     expect(PlayStoreResults.version(response), '2.1.6');
   }, skip: false);


### PR DESCRIPTION
1. Android Without Appcast
I have implemented a functionality that will allow Android updates without Appcast. The feature will pull the App's latest version and release notes from the PlayStore just like how the iTunes version of the iOS is implemented. It also allow developers to optionally  enter the Android ID of their apps in UpgradeAlert and UpgradeCard if it is different from what is currently in their app. The only package I added was dart html to parse the html I am downloading from the PlayStore.

2. AlertDialog Buttons
I have changed the UpdateNow button to an ElevatedButton since is a call to action button and must be different from Ignore and Later.

![Screenshot_20210628-041918](https://user-images.githubusercontent.com/19711677/123613673-40c54300-d7c9-11eb-8ddb-4d8f1470670c.png)

