### PR TITLE
Release notes not having the 'What\'s New' section

### DIFF
--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -59,7 +59,7 @@ class PlayStoreResults {
     try {
       final sectionElements = response.getElementsByClassName('W4P4ne');
       final releaseNotesElement = sectionElements.firstWhere(
-        (elm) => elm.querySelector('.wSaTQd')!.text == 'What\'s New',
+        (elm) => elm.querySelector('.wSaTQd')!.text == 'What\'s New',orElse:()=> sectionElements[0]
       );
       final releaseNotes = releaseNotesElement
           .querySelector('.PHBdkd')


### PR DESCRIPTION
Return the first section if  'What\'s New' isn't there in an apps release notes.