### PR TITLE
Custom dialog support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,7 +32,50 @@ class MyApp extends StatelessWidget {
           body: UpgradeAlert(
             debugLogging: true,
             child: Center(child: Text('Checking...')),
+            getCustomDialog: getCustomDialog,
           )),
     );
   }
+}
+
+/// Example Custom Dialog Widget
+Widget getCustomDialog(BuildContext context,
+    {String title,
+    String message,
+    String releaseNotes,
+    void Function() onUserIgnored,
+    void Function() onUserLater,
+    void Function() onUserUpdated}) {
+  return Center(
+    child: Container(
+      height: 124,
+      width: MediaQuery.of(context).size.width * 0.8,
+      color: Colors.white,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            'Your Custom Upgrader Dialog',
+          ),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextButton(onPressed: onUserIgnored, child: Text('IGNORE')),
+              TextButton(onPressed: onUserLater, child: Text('LATER')),
+              TextButton(
+                onPressed: onUserUpdated,
+                child: Text(
+                  'UPDATE',
+                  style: TextStyle(
+                    color: Colors.black,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    ),
+  );
 }

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -33,6 +33,7 @@ class UpgradeAlert extends UpgradeBase {
     String? countryCode,
     String? minAppVersion,
     UpgradeDialogStyle? dialogStyle,
+    Widget? Function(BuildContext context, {String? title, String? message, String? releaseNotes, void Function()? onUserIgnored, void Function()? onUserLater, void Function()? onUserUpdated})? getCustomDialog,
   }) : super(
           key: key,
           appcastConfig: appcastConfig,
@@ -53,6 +54,7 @@ class UpgradeAlert extends UpgradeBase {
           countryCode: countryCode,
           minAppVersion: minAppVersion,
           dialogStyle: dialogStyle,
+          getCustomDialog: getCustomDialog,
         );
 
   @override

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -33,7 +33,16 @@ class UpgradeAlert extends UpgradeBase {
     String? countryCode,
     String? minAppVersion,
     UpgradeDialogStyle? dialogStyle,
-    Widget? Function(BuildContext context, {String? title, String? message, String? releaseNotes, void Function()? onUserIgnored, void Function()? onUserLater, void Function()? onUserUpdated})? getCustomDialog,
+    Widget? Function(
+      BuildContext context, {
+      String? title,
+      String? message,
+      String? releaseNotes,
+      void Function()? onUserIgnored,
+      void Function()? onUserLater,
+      void Function()? onUserUpdated,
+    })?
+        getCustomDialog,
   }) : super(
           key: key,
           appcastConfig: appcastConfig,

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -68,6 +68,15 @@ class UpgradeBase extends StatefulWidget {
   /// The upgrade dialog style. Optional. Used only on UpgradeAlert. (default: material)
   final UpgradeDialogStyle? dialogStyle;
 
+  /// The function which returns the custom widget to be shown in place of default alert dialogs
+  Widget? Function(BuildContext context,
+      {String? title,
+      String? message,
+      String? releaseNotes,
+      void Function()? onUserIgnored,
+      void Function()? onUserLater,
+      void Function()? onUserUpdated})? getCustomDialog;
+
   UpgradeBase({
     Key? key,
     this.appcastConfig,
@@ -88,6 +97,7 @@ class UpgradeBase extends StatefulWidget {
     this.countryCode,
     this.minAppVersion,
     this.dialogStyle = UpgradeDialogStyle.material,
+    this.getCustomDialog,
   }) : super(key: key) {
     if (appcastConfig != null) {
       Upgrader().appcastConfig = appcastConfig;
@@ -142,6 +152,9 @@ class UpgradeBase extends StatefulWidget {
     }
     if (dialogStyle != null) {
       Upgrader().dialogStyle = dialogStyle;
+    }
+    if (getCustomDialog != null) {
+      Upgrader().getCustomDialog = getCustomDialog;
     }
   }
 

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -68,7 +68,8 @@ class UpgradeBase extends StatefulWidget {
   /// The upgrade dialog style. Optional. Used only on UpgradeAlert. (default: material)
   final UpgradeDialogStyle? dialogStyle;
 
-  /// The function which returns the custom widget to be shown in place of default alert dialogs
+  /// The function which returns the custom widget to be shown
+  /// in place of default alert dialogs
   final Widget? Function(BuildContext context,
       {String? title,
       String? message,

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -69,7 +69,7 @@ class UpgradeBase extends StatefulWidget {
   final UpgradeDialogStyle? dialogStyle;
 
   /// The function which returns the custom widget to be shown in place of default alert dialogs
-  Widget? Function(BuildContext context,
+  final Widget? Function(BuildContext context,
       {String? title,
       String? message,
       String? releaseNotes,

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -115,6 +115,15 @@ class Upgrader {
   /// The target operating system.
   String operatingSystem = Platform.operatingSystem;
 
+  /// The function which returns the custom widget to be shown in place of default alert dialogs
+  Widget? Function(BuildContext context,
+      {String? title,
+      String? message,
+      String? releaseNotes,
+      void Function()? onUserIgnored,
+      void Function()? onUserLater,
+      void Function()? onUserUpdated})? getCustomDialog;
+
   bool _displayed = false;
   bool _initCalled = false;
   PackageInfo? _packageInfo;
@@ -474,9 +483,26 @@ class Upgrader {
       builder: (BuildContext context) {
         return WillPopScope(
           onWillPop: () async => _shouldPopScope(),
-          child: dialogStyle == UpgradeDialogStyle.material
-              ? _alertDialog(title!, message, releaseNotes, context)
-              : _cupertinoAlertDialog(title!, message, releaseNotes, context),
+          child: getCustomDialog != null
+              ? getCustomDialog!(
+                  context,
+                  title: title,
+                  message: message,
+                  releaseNotes: releaseNotes,
+                  onUserIgnored: () {
+                    onUserIgnored(context, true);
+                  },
+                  onUserLater: () {
+                    onUserLater(context, true);
+                  },
+                  onUserUpdated: () {
+                    onUserUpdated(context, !blocked());
+                  },
+                )!
+              : dialogStyle == UpgradeDialogStyle.material
+                  ? _alertDialog(title!, message, releaseNotes, context)
+                  : _cupertinoAlertDialog(
+                      title!, message, releaseNotes, context),
         );
       },
     );

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -115,7 +115,8 @@ class Upgrader {
   /// The target operating system.
   String operatingSystem = Platform.operatingSystem;
 
-  /// The function which returns the custom widget to be shown in place of default alert dialogs
+  /// The function which returns the custom widget to be shown
+  /// in place of default alert dialogs
   Widget? Function(BuildContext context,
       {String? title,
       String? message,


### PR DESCRIPTION
Hi! First of all, I have to say, this is such a useful package. Thank you so much for this package. 

## Problem Statement
Although the package fulfills the basic needs of most of the apps but for certain brand-centric apps, we need to use a very different UI from those standard materials & Cupertino alert dialogs.

### Choices users have in such a case:
- Build a whole new package to cater to the need which the upgrader already fulfills & add their custom dialog widget.
- Go through the upgrader's codebase & try to customize it as per the need

## Solution proposed:
- It will be very useful if we allow users to pass a method that will then be called inside the upgrader at a suitable time. This allows users to show literally any kind of UI they want to.

Method signature
```dart
Widget getCustomDialog(BuildContext context,
    {String title,
    String message,
    String releaseNotes,
    void Function() onUserIgnored,
    void Function() onUserLater,
    void Function() onUserUpdated});
```
or
with null safety
```dart
Widget getCustomDialog(BuildContext context,
    {String? title,
    String? message,
    String? releaseNotes,
    void Function()? onUserIgnored,
    void Function()? onUserLater,
    void Function()? onUserUpdated});
```

## Changes in this pull request:
- [x] Added logic to show custom dialog
- [x] Updated the example/main.dart to show usage of custom dialog widget

@larryaasen I hope you will find this contribution a valid one. Looking forward to contributing to this amazing package!

## Reference screenshot:

<img height="624px" width="324px" src="https://user-images.githubusercontent.com/49445823/136369395-20c3f156-57d2-4d27-929a-b31454f68f01.png">