### PR TITLE
Remove the use of a singleton for Upgrader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This makes it easy to subclass Upgrader and change its behavior. The parameters
 to UpgradeAlert and UpgradeCard have been removed, and can be set on Upgrader.
 See the various examples for more information.
 
+Updated url_launcher to version 6.1.0.
+
 There are no new features, no feature updates, and no bug fixes in this release.
 
 ## 3.14.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.0-alpha.1
 
-* No more singleton. This is a huge update to remove the use of a singleton for Upgrader.
+[BREAKING]
+No more singleton. This is a huge update to remove the use of a singleton for Upgrader.
 It is now a normal class that is passed to either UpgradeAlert or UpgradeCard.
 This makes it easy to subclass Upgrader and change its behavior. The parameters
 to UpgradeAlert and UpgradeCard have been removed, and can be set on Upgrader.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0-alpha.2
+
+The Upgrader class is now used as a shared instance with UpgradeAlert and UpgradeCard.
+
+There are no new features, no feature updates, and no bug fixes in this release.
+
 ## 4.0.0-alpha.1
 
 [BREAKING]
@@ -6,6 +12,8 @@ It is now a normal class that is passed to either UpgradeAlert or UpgradeCard.
 This makes it easy to subclass Upgrader and change its behavior. The parameters
 to UpgradeAlert and UpgradeCard have been removed, and can be set on Upgrader.
 See the various examples for more information.
+
+There are no new features, no feature updates, and no bug fixes in this release.
 
 ## 3.14.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 4.0.0
+
+* [BREAKING] No more singleton. This is a huge update to remove the use of a singleton for Upgrader.
+It is now a normal class that is passed to either UpgradeAlert or UpgradeCard.
+This makes it easy to subclass Upgrader and change its behavior. The parameters
+to UpgradeAlert and UpgradeCard have been removed, and can be set on Upgrader.
+See the various examples for more information.
+
+* Changed the callback signature for the willDisplayUpgrade callback to add
+minAppVersion, installedVersion, and appStoreVersion parameters.
+
+* Updated url_launcher to version 6.1.0.
+
+* There are no new features, no feature updates, and no bug fixes in this release.
+
 ## 4.0.0-alpha.4
 
 [BREAKING]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.0.0-alpha.1
+
+* No more singleton. This is a huge update to remove the use of a singleton for Upgrader.
+It is now a normal class that is passed to either UpgradeAlert or UpgradeCard.
+This makes it easy to subclass Upgrader and change its behavior. The parameters
+to UpgradeAlert and UpgradeCard have been removed, and can be set on Upgrader.
+See the various examples for more information.
+
 ## 3.14.0
 
 * BREAKING (Minor): Changed the parameter name `debugAlwaysUpgrade` to `debugDisplayAlways`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0-alpha.3
+
+Moved the upgrader parameter for UpgradeCard to a named parameter.
+
+There are no new features, no feature updates, and no bug fixes in this release.
+
 ## 4.0.0-alpha.2
 
 The Upgrader class is now used as a shared instance with UpgradeAlert and UpgradeCard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0-alpha.4
+
+[BREAKING]
+Changed the callback signature for the willDisplayUpgrade callback to add
+minAppVersion, installedVersion, and appStoreVersion parameters.
+
 ## 4.0.0-alpha.3
 
 Moved the upgrader parameter for UpgradeCard to a named parameter.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2018-2021, Larry Aasen.
+Copyright (c) 2018-2022, Larry Aasen.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/README.md
+++ b/README.md
@@ -69,22 +69,18 @@ import 'package:upgrader/upgrader.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-  MyApp({
-    Key key,
-  }) : super(key: key);
+  const MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Upgrader Example',
       home: Scaffold(
-          appBar: AppBar(
-            title: Text('Upgrader Example'),
-          ),
+          appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
+            Upgrader(),
             child: Center(child: Text('Checking...')),
-          )
-      ),
+          )),
     );
   }
 }
@@ -100,7 +96,7 @@ class MyApp extends StatelessWidget {
 You can also display a Cupertino style dialog by using the `dialogStyle` parameter.
 ```dart
           body: UpgradeAlert(
-            dialogStyle: UpgradeDialogStyle.cupertino,
+            Upgrader(dialogStyle: UpgradeDialogStyle.cupertino),
             child: Center(child: Text('Checking...')),
           )
 ```
@@ -116,7 +112,7 @@ when an update is detected. The widget will have width and height of 0.0 when no
 ```dart
 return Container(
         margin: EdgeInsets.fromLTRB(12.0, 0.0, 12.0, 0.0),
-        child: UpgradeCard());
+        child: UpgradeCard(Upgrader()));
 ```
 
 ## Screenshot of card
@@ -125,29 +121,30 @@ return Container(
 
 ## Customization
 
-The UpgradeAlert widget can be customized by setting parameters in the constructor of the
-UpgradeAlert widget.
+The Upgrader class can be customized by setting parameters in the constructor.
 
+* appcast: Provide an Appcast that can be replaced for mock testing, defaults to ```null```
 * appcastConfig: the appcast configuration, defaults to ```null```
+* canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by UpgradeCard)
+* countryCode: the country code that will override the system locale, which defaults to ```null``` (iOS only)
 * client: an HTTP Client that can be replaced for mock testing, defaults to ```null```
-* durationUntilAlertAgain: duration until alerting user again, which defaults to ```3 days```
 * debugDisplayAlways: always force the upgrade to be available, defaults to ```false```
 * debugDisplayOnce: display the upgrade at least once once, defaults to ```false```
 * debugLogging: display logging statements, which defaults to ```false```
+* dialogStyle: the upgrade dialog style, either ```material``` or ```cupertino```, defaults to ```material```, used only by UpgradeAlert, works on Android and iOS.
+* durationUntilAlertAgain: duration until alerting user again, which defaults to ```3 days```
 * messages: optional localized messages used for display in `upgrader`
+* minAppVersion: the minimum app version supported by this app. Earlier versions of this app will be forced to update to the current version. Defaults to ```null```.
 * onIgnore: called when the ignore button is tapped, defaults to ```null```
 * onLater: called when the later button is tapped, defaults to ```null```
 * onUpdate: called when the update button is tapped, defaults to ```null```
+* platform: The target platform, defaults to ```defaultTargetPlatform```
 * shouldPopScope: called when the back button is tapped, defaults to ```null```
-* willDisplayUpgrade: called when ```upgrader``` determines that an upgrade may
-or may not be displayed, defaults to ```null```
 * showIgnore: hide or show Ignore button, which defaults to ```true```
 * showLater: hide or show Later button, which defaults to ```true```
 * showReleaseNotes: hide or show release notes, which defaults to ```true```
-* canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by UpgradeCard)
-* countryCode: the country code that will override the system locale, which defaults to ```null``` (iOS only)
-* minAppVersion: the minimum app version supported by this app. Earlier versions of this app will be forced to update to the current version. Defaults to ```null```.
-* dialogStyle: the upgrade dialog style, either ```material``` or ```cupertino```, defaults to ```material```, used only by UpgradeAlert, works on Android and iOS.
+* willDisplayUpgrade: called when ```upgrader``` determines that an upgrade may
+or may not be displayed, defaults to ```null```
 
 ## Android Back Button
 
@@ -155,7 +152,7 @@ When using the ```UpgradeAlert``` widget, the Android back button will not
 dismiss the alert dialog by default. To allow the back button to dismiss the
 dialog, use ```shouldPopScope``` and return true like this:
 ```
-UpgradeAlert(
+Upgrader(
   shouldPopScope: () => true,
 );
 ```
@@ -220,7 +217,7 @@ Widget build(BuildContext context) {
           title: Text('Upgrader Example'),
         ),
         body: UpgradeAlert(
-          appcastConfig: cfg,
+          Upgrader(appcastConfig: cfg),
           child: Center(child: Text('Checking...')),
         )),
   );
@@ -266,7 +263,7 @@ class MyUpgraderMessages extends UpgraderMessages {
   String get buttonTitleIgnore => 'My Ignore';
 }
 
-UpgradeAlert(messages: MyUpgraderMessages());
+UpgradeAlert(Upgrader(messages: MyUpgraderMessages()));
 ```
 
 ## Language localization
@@ -338,7 +335,7 @@ class MySpanishMessages extends UpgraderMessages {
   }
 }
 
-UpgradeAlert(messages: MySpanishMessages());
+UpgradeAlert(Upgrader(messages: MySpanishMessages()));
 ```
 
 You can even force the `upgrader` package to use a specific language, instead of the
@@ -346,7 +343,7 @@ system language on the device. Just pass the language code to an instance of
 UpgraderMessages when displaying the alert or card. Here is an example:
 
 ```dart
-UpgradeAlert(messages: UpgraderMessages(code: 'es'));
+UpgradeAlert(Upgrader(messages: UpgraderMessages(code: 'es')));
 ```
 
 ## Semantic Versioning

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
           appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            Upgrader(),
             child: Center(child: Text('Checking...')),
           )),
     );
@@ -112,7 +111,7 @@ when an update is detected. The widget will have width and height of 0.0 when no
 ```dart
 return Container(
         margin: EdgeInsets.fromLTRB(12.0, 0.0, 12.0, 0.0),
-        child: UpgradeCard(Upgrader()));
+        child: UpgradeCard());
 ```
 
 ## Screenshot of card

--- a/README.md
+++ b/README.md
@@ -151,9 +151,7 @@ When using the ```UpgradeAlert``` widget, the Android back button will not
 dismiss the alert dialog by default. To allow the back button to dismiss the
 dialog, use ```shouldPopScope``` and return true like this:
 ```
-Upgrader(
-  shouldPopScope: () => true,
-);
+UpgradeAlert(Upgrader(shouldPopScope: () => true));
 ```
 
 ## iOS Country Code

--- a/example/lib/main-appcast.dart
+++ b/example/lib/main-appcast.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Larry Aasen. All rights reserved.
+ * Copyright (c) 2019-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';

--- a/example/lib/main-appcast.dart
+++ b/example/lib/main-appcast.dart
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
           appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            Upgrader(
+            upgrader: Upgrader(
               appcastConfig: cfg,
               debugLogging: true,
             ),

--- a/example/lib/main-appcast.dart
+++ b/example/lib/main-appcast.dart
@@ -5,22 +5,24 @@
 import 'package:flutter/material.dart';
 import 'package:upgrader/upgrader.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Only call clearSavedSettings() during testing to reset internal values.
+  await Upgrader.clearSavedSettings(); // REMOVE this for release builds
+
+  // On Android, setup the Appcast.
+  // On iOS, the default behavior will be to use the App Store version of
+  // the app, so update the Bundle Identifier in example/ios/Runner with a
+  // valid identifier already in the App Store.
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
-  MyApp({
-    Key key,
-  }) : super(key: key);
+  MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // Only call clearSavedSettings() during testing to reset internal values.
-    Upgrader().clearSavedSettings(); // REMOVE this for release builds
-
-    // On Android, setup the Appcast.
-    // On iOS, the default behavior will be to use the App Store version of
-    // the app, so update the Bundle Identifier in example/ios/Runner with a
-    // valid identifier already in the App Store.
     final appcastURL =
         'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
     final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
@@ -28,12 +30,12 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Upgrader Example',
       home: Scaffold(
-          appBar: AppBar(
-            title: Text('Upgrader Example'),
-          ),
+          appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            appcastConfig: cfg,
-            debugLogging: true,
+            Upgrader(
+              appcastConfig: cfg,
+              debugLogging: true,
+            ),
             child: Center(child: Text('Checking...')),
           )),
     );

--- a/example/lib/main-card.dart
+++ b/example/lib/main-card.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Larry Aasen. All rights reserved.
+ * Copyright (c) 2019-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';

--- a/example/lib/main-card.dart
+++ b/example/lib/main-card.dart
@@ -5,22 +5,24 @@
 import 'package:flutter/material.dart';
 import 'package:upgrader/upgrader.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Only call clearSavedSettings() during testing to reset internal values.
+  await Upgrader.clearSavedSettings(); // REMOVE this for release builds
+
+  // On Android, setup the Appcast.
+  // On iOS, the default behavior will be to use the App Store version of
+  // the app, so update the Bundle Identifier in example/ios/Runner with a
+  // valid identifier already in the App Store.
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
-  MyApp({
-    Key key,
-  }) : super(key: key);
+  MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // Only call clearSavedSettings() during testing to reset internal values.
-    Upgrader().clearSavedSettings(); // REMOVE this for release builds
-
-    // On Android, setup the Appcast.
-    // On iOS, the default behavior will be to use the App Store version of
-    // the app, so update the Bundle Identifier in example/ios/Runner with a
-    // valid identifier already in the App Store.
     final appcastURL =
         'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
     final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
@@ -28,15 +30,15 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Upgrader Example',
       home: Scaffold(
-          appBar: AppBar(
-            title: Text('Upgrader Example'),
-          ),
+          appBar: AppBar(title: Text('Upgrader Example')),
           body: Center(
               child: Container(
                   margin: EdgeInsets.fromLTRB(12.0, 0.0, 12.0, 0.0),
                   child: UpgradeCard(
-                    appcastConfig: cfg,
-                    debugLogging: true,
+                    Upgrader(
+                      appcastConfig: cfg,
+                      debugLogging: true,
+                    ),
                   )))),
     );
   }

--- a/example/lib/main-card.dart
+++ b/example/lib/main-card.dart
@@ -35,7 +35,7 @@ class MyApp extends StatelessWidget {
               child: Container(
                   margin: EdgeInsets.fromLTRB(12.0, 0.0, 12.0, 0.0),
                   child: UpgradeCard(
-                    Upgrader(
+                    upgrader: Upgrader(
                       appcastConfig: cfg,
                       debugLogging: true,
                     ),

--- a/example/lib/main-cupertino.dart
+++ b/example/lib/main-cupertino.dart
@@ -5,22 +5,24 @@
 import 'package:flutter/material.dart';
 import 'package:upgrader/upgrader.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Only call clearSavedSettings() during testing to reset internal values.
+  await Upgrader.clearSavedSettings(); // REMOVE this for release builds
+
+  // On Android, setup the Appcast.
+  // On iOS, the default behavior will be to use the App Store version of
+  // the app, so update the Bundle Identifier in example/ios/Runner with a
+  // valid identifier already in the App Store.
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
-  MyApp({
-    Key key,
-  }) : super(key: key);
+  MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // Only call clearSavedSettings() during testing to reset internal values.
-    Upgrader().clearSavedSettings(); // REMOVE this for release builds
-
-    // On Android, setup the Appcast.
-    // On iOS, the default behavior will be to use the App Store version of
-    // the app, so update the Bundle Identifier in example/ios/Runner with a
-    // valid identifier already in the App Store.
     final appcastURL =
         'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
     final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
@@ -28,13 +30,13 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Upgrader Example',
       home: Scaffold(
-          appBar: AppBar(
-            title: Text('Upgrader Example'),
-          ),
+          appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            appcastConfig: cfg,
-            debugLogging: true,
-            dialogStyle: UpgradeDialogStyle.cupertino,
+            Upgrader(
+              appcastConfig: cfg,
+              debugLogging: true,
+              dialogStyle: UpgradeDialogStyle.cupertino,
+            ),
             child: Center(child: Text('Checking...')),
           )),
     );

--- a/example/lib/main-cupertino.dart
+++ b/example/lib/main-cupertino.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Larry Aasen. All rights reserved.
+ * Copyright (c) 2020-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';

--- a/example/lib/main-cupertino.dart
+++ b/example/lib/main-cupertino.dart
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
           appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            Upgrader(
+            upgrader: Upgrader(
               appcastConfig: cfg,
               debugLogging: true,
               dialogStyle: UpgradeDialogStyle.cupertino,

--- a/example/lib/main-localized.dart
+++ b/example/lib/main-localized.dart
@@ -7,12 +7,21 @@ import 'package:flutter/foundation.dart' show SynchronousFuture;
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:upgrader/upgrader.dart';
 
-void main() => runApp(Demo());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Only call clearSavedSettings() during testing to reset internal values.
+  await Upgrader.clearSavedSettings(); // REMOVE this for release builds
+
+  // On Android, setup the Appcast.
+  // On iOS, the default behavior will be to use the App Store version of
+  // the app, so update the Bundle Identifier in example/ios/Runner with a
+  // valid identifier already in the App Store.
+  runApp(Demo());
+}
 
 class Demo extends StatelessWidget {
-  Demo({
-    Key key,
-  }) : super(key: key);
+  Demo({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -62,25 +71,18 @@ class Demo extends StatelessWidget {
 class DemoApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // Only call clearSavedSettings() during testing to reset internal values.
-    Upgrader().clearSavedSettings(); // REMOVE this for release builds
-
-    // On Android, setup the Appcast.
-    // On iOS, the default behavior will be to use the App Store version of
-    // the app, so update the Bundle Identifier in example/ios/Runner with a
-    // valid identifier already in the App Store.
     final appcastURL =
         'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
     final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
 
     return Scaffold(
-        appBar: AppBar(
-          title: Text(DemoLocalizations.of(context).title),
-        ),
+        appBar: AppBar(title: Text(DemoLocalizations.of(context).title)),
         body: UpgradeAlert(
-          appcastConfig: cfg,
-          debugLogging: true,
-          messages: MyUpgraderMessages(),
+          Upgrader(
+            appcastConfig: cfg,
+            debugLogging: true,
+            messages: MyUpgraderMessages(code: 'es'),
+          ),
           child: Center(child: Text(DemoLocalizations.of(context).checking)),
         ));
   }
@@ -166,6 +168,8 @@ class MyUpgraderMessages extends UpgraderMessages {
   /// provided in the [message] function will be used over this value.
   @override
   String get buttonTitleIgnore => 'My Ignore 1';
+
+  MyUpgraderMessages({String code}) : super(code: code);
 
   /// Override the message function to provide your own language localization.
   @override

--- a/example/lib/main-localized.dart
+++ b/example/lib/main-localized.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020 Larry Aasen. All rights reserved.
+ * Copyright (c) 2020-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';

--- a/example/lib/main-localized.dart
+++ b/example/lib/main-localized.dart
@@ -78,7 +78,7 @@ class DemoApp extends StatelessWidget {
     return Scaffold(
         appBar: AppBar(title: Text(DemoLocalizations.of(context).title)),
         body: UpgradeAlert(
-          Upgrader(
+          upgrader: Upgrader(
             appcastConfig: cfg,
             debugLogging: true,
             messages: MyUpgraderMessages(code: 'es'),

--- a/example/lib/main-min-app-version.dart
+++ b/example/lib/main-min-app-version.dart
@@ -32,7 +32,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
           appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            Upgrader(
+            upgrader: Upgrader(
               appcastConfig: cfg,
               debugLogging: true,
               minAppVersion: '1.1.0',

--- a/example/lib/main-min-app-version.dart
+++ b/example/lib/main-min-app-version.dart
@@ -5,22 +5,24 @@
 import 'package:flutter/material.dart';
 import 'package:upgrader/upgrader.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Only call clearSavedSettings() during testing to reset internal values.
+  await Upgrader.clearSavedSettings(); // REMOVE this for release builds
+
+  // On Android, setup the Appcast.
+  // On iOS, the default behavior will be to use the App Store version of
+  // the app, so update the Bundle Identifier in example/ios/Runner with a
+  // valid identifier already in the App Store.
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
-  MyApp({
-    Key key,
-  }) : super(key: key);
+  MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // Only call clearSavedSettings() during testing to reset internal values.
-    Upgrader().clearSavedSettings(); // REMOVE this for release builds
-
-    // On Android, setup the Appcast.
-    // On iOS, the default behavior will be to use the App Store version of
-    // the app, so update the Bundle Identifier in example/ios/Runner with a
-    // valid identifier already in the App Store.
     final appcastURL =
         'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
     final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
@@ -28,14 +30,14 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Upgrader Example',
       home: Scaffold(
-          appBar: AppBar(
-            title: Text('Upgrader Example'),
-          ),
+          appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            appcastConfig: cfg,
-            debugLogging: true,
+            Upgrader(
+              appcastConfig: cfg,
+              debugLogging: true,
+              minAppVersion: '1.1.0',
+            ),
             child: Center(child: Text('Checking...')),
-            minAppVersion: '1.1.0',
           )),
     );
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -29,7 +29,6 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
           appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            Upgrader(debugLogging: true),
             child: Center(child: Text('Checking...')),
           )),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,36 +1,35 @@
 /*
- * Copyright (c) 2019 Larry Aasen. All rights reserved.
+ * Copyright (c) 2019-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';
 import 'package:upgrader/upgrader.dart';
 
-void main() => runApp(MyApp());
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Only call clearSavedSettings() during testing to reset internal values.
+  await Upgrader.clearSavedSettings(); // REMOVE this for release builds
+
+  // On Android, the default behavior will be to use the Google Play Store
+  // version of the app.
+  // On iOS, the default behavior will be to use the App Store version of
+  // the app, so update the Bundle Identifier in example/ios/Runner with a
+  // valid identifier already in the App Store.
+  runApp(MyApp());
+}
 
 class MyApp extends StatelessWidget {
-  const MyApp({
-    Key key,
-  }) : super(key: key);
+  const MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    // Only call clearSavedSettings() during testing to reset internal values.
-    Upgrader().clearSavedSettings(); // REMOVE this for release builds
-
-    // On Android, the default behavior will be to use the Google Play Store
-    // version of the app.
-    // On iOS, the default behavior will be to use the App Store version of
-    // the app, so update the Bundle Identifier in example/ios/Runner with a
-    // valid identifier already in the App Store.
-
     return MaterialApp(
       title: 'Upgrader Example',
       home: Scaffold(
-          appBar: AppBar(
-            title: Text('Upgrader Example'),
-          ),
+          appBar: AppBar(title: Text('Upgrader Example')),
           body: UpgradeAlert(
-            debugLogging: true,
+            Upgrader(debugLogging: true),
             child: Center(child: Text('Checking...')),
           )),
     );

--- a/example/lib/main_subclass.dart
+++ b/example/lib/main_subclass.dart
@@ -29,7 +29,7 @@ class MyApp extends StatelessWidget {
       home: Scaffold(
           appBar: AppBar(title: Text('Upgrader Subclass Example')),
           body: UpgradeAlert(
-            MyUpgrader(),
+            upgrader: MyUpgrader(),
             child: Center(child: Text('Checking...')),
           )),
     );

--- a/example/lib/main_subclass.dart
+++ b/example/lib/main_subclass.dart
@@ -11,7 +11,8 @@ void main() async {
   // Only call clearSavedSettings() during testing to reset internal values.
   await Upgrader.clearSavedSettings(); // REMOVE this for release builds
 
-  // On Android, setup the Appcast.
+  // On Android, the default behavior will be to use the Google Play Store
+  // version of the app.
   // On iOS, the default behavior will be to use the App Store version of
   // the app, so update the Bundle Identifier in example/ios/Runner with a
   // valid identifier already in the App Store.
@@ -19,26 +20,30 @@ void main() async {
 }
 
 class MyApp extends StatelessWidget {
-  MyApp({Key key}) : super(key: key);
+  const MyApp({Key key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final appcastURL =
-        'https://raw.githubusercontent.com/larryaasen/upgrader/master/test/testappcast.xml';
-    final cfg = AppcastConfiguration(url: appcastURL, supportedOS: ['android']);
-
     return MaterialApp(
-      title: 'Upgrader Example',
+      title: 'Upgrader Subclass Example',
       home: Scaffold(
-          appBar: AppBar(title: Text('Upgrader Example')),
+          appBar: AppBar(title: Text('Upgrader Subclass Example')),
           body: UpgradeAlert(
-            Upgrader(
-              appcastConfig: cfg,
-              debugLogging: true,
-              minAppVersion: '1.1.0',
-            ),
+            MyUpgrader(),
             child: Center(child: Text('Checking...')),
           )),
     );
+  }
+}
+
+/// This class extends / subclasses Upgrader.
+class MyUpgrader extends Upgrader {
+  MyUpgrader() : super(debugLogging: true);
+
+  /// This method overrides super class method.
+  @override
+  void popNavigator(BuildContext context) {
+    print('this method overrides popNavigator');
+    super.popNavigator(context);
   }
 }

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -10,9 +10,11 @@ class UpgradeAlert extends UpgradeBase {
   /// The [child] contained by the widget.
   final Widget? child;
 
-  const UpgradeAlert(Upgrader upgrader, {Key? key, this.child})
-      : super(upgrader, key: key);
+  /// Creates a new [UpgradeAlert].
+  UpgradeAlert({Key? key, Upgrader? upgrader, this.child})
+      : super(upgrader ?? Upgrader.sharedInstance, key: key);
 
+  /// Describes the part of the user interface represented by this widget.
   @override
   Widget build(BuildContext context, UpgradeBaseState state) {
     if (upgrader.debugLogging) {
@@ -27,7 +29,7 @@ class UpgradeAlert extends UpgradeBase {
               processed.data!) {
             upgrader.checkVersion(context: context);
           }
-          return child!;
+          return child ?? Container();
         });
   }
 }

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -1,9 +1,8 @@
 /*
- * Copyright (c) 2021 Larry Aasen. All rights reserved.
+ * Copyright (c) 2021-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:upgrader/upgrader.dart';
 
 /// A widget to display the upgrade dialog.
@@ -11,54 +10,12 @@ class UpgradeAlert extends UpgradeBase {
   /// The [child] contained by the widget.
   final Widget? child;
 
-  UpgradeAlert({
-    Key? key,
-    AppcastConfiguration? appcastConfig,
-    UpgraderMessages? messages,
-    this.child,
-    bool? debugDisplayAlways,
-    bool? debugDisplayOnce,
-    bool? debugLogging,
-    Duration? durationToAlertAgain,
-    BoolCallback? onIgnore,
-    BoolCallback? onLater,
-    BoolCallback? onUpdate,
-    BoolCallback? shouldPopScope,
-    VoidBoolCallback? willDisplayUpgrade,
-    http.Client? client,
-    bool? showIgnore,
-    bool? showLater,
-    bool? showReleaseNotes,
-    bool? canDismissDialog,
-    String? countryCode,
-    String? minAppVersion,
-    UpgradeDialogStyle? dialogStyle,
-  }) : super(
-          key: key,
-          appcastConfig: appcastConfig,
-          messages: messages,
-          debugDisplayAlways: debugDisplayAlways,
-          debugDisplayOnce: debugDisplayOnce,
-          debugLogging: debugLogging,
-          durationToAlertAgain: durationToAlertAgain,
-          onIgnore: onIgnore,
-          onLater: onLater,
-          onUpdate: onUpdate,
-          shouldPopScope: shouldPopScope,
-          willDisplayUpgrade: willDisplayUpgrade,
-          client: client,
-          showIgnore: showIgnore,
-          showLater: showLater,
-          showReleaseNotes: showReleaseNotes,
-          canDismissDialog: canDismissDialog,
-          countryCode: countryCode,
-          minAppVersion: minAppVersion,
-          dialogStyle: dialogStyle,
-        );
+  const UpgradeAlert(Upgrader upgrader, {Key? key, this.child})
+      : super(upgrader, key: key);
 
   @override
   Widget build(BuildContext context, UpgradeBaseState state) {
-    if (Upgrader().debugLogging) {
+    if (upgrader.debugLogging) {
       print('upgrader: build UpgradeAlert');
     }
 
@@ -68,7 +25,7 @@ class UpgradeAlert extends UpgradeBase {
           if (processed.connectionState == ConnectionState.done &&
               processed.data != null &&
               processed.data!) {
-            Upgrader().checkVersion(context: context);
+            upgrader.checkVersion(context: context);
           }
           return child!;
         });

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Larry Aasen. All rights reserved.
+ * Copyright (c) 2018-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -3,159 +3,19 @@
  */
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:upgrader/upgrader.dart';
 
 class UpgradeBase extends StatefulWidget {
-  /// The appcast configuration ([AppcastConfiguration]) used by [Appcast].
-  final AppcastConfiguration? appcastConfig;
+  /// The upgraders used to configure the upgrade dialog.
+  final Upgrader upgrader;
 
-  /// The localized messages used for display in upgrader.
-  final UpgraderMessages? messages;
-
-  /// For debugging, always force the upgrade to be available.
-  final bool? debugDisplayAlways;
-
-  /// For debugging, display the upgrade at least once once.
-  final bool? debugDisplayOnce;
-
-  /// For debugging, display logging statements.
-  final bool? debugLogging;
-
-  /// Duration until alerting user again after later.
-  Duration get durationToAlertAgain => Upgrader().durationUntilAlertAgain;
-
-  /// Called when the ignore button is tapped or otherwise activated.
-  /// Return false when the default behavior should not execute.
-  final BoolCallback? onIgnore;
-
-  /// Called when the ignore button is tapped or otherwise activated.
-  /// Return false when the default behavior should not execute.
-  final BoolCallback? onLater;
-
-  /// Called when the ignore button is tapped or otherwise activated.
-  /// Return false when the default behavior should not execute.
-  final BoolCallback? onUpdate;
-
-  /// Called when the user taps outside of the dialog and [canDismissDialog]
-  /// is false. Also called when the back button is pressed. Return true for
-  /// the screen to be popped. Not used by [UpgradeCard].
-  final BoolCallback? shouldPopScope;
-
-  /// Called when [Upgrader] determines that an upgrade may or may not be
-  /// displayed. The [value] parameter will be true when it should be displayed,
-  /// and false when it should not be displayed. One good use for this callback
-  /// is logging metrics for your app.
-  final VoidBoolCallback? willDisplayUpgrade;
-
-  /// Provide an HTTP Client that can be replaced for mock testing.
-  final http.Client? client;
-
-  /// Hide or show Ignore button on dialog (default: true)
-  final bool? showIgnore;
-
-  /// Hide or show Later button on dialog (default: true)
-  final bool? showLater;
-
-  /// Hide or show release notes (default: true)
-  final bool? showReleaseNotes;
-
-  /// Can alert dialog be dismissed on tap outside of the alert dialog. Not used by [UpgradeCard]. (default: false)
-  final bool? canDismissDialog;
-
-  /// The country code that will override the system locale. Optional. Used only for iOS.
-  final String? countryCode;
-
-  /// The minimum app version supported by this app. Earlier versions of this app
-  /// will be forced to update to the current version. Optional.
-  final String? minAppVersion;
-
-  /// The upgrade dialog style. Optional. Used only on UpgradeAlert. (default: material)
-  final UpgradeDialogStyle? dialogStyle;
-
-  UpgradeBase({
+  const UpgradeBase(
+    this.upgrader, {
     Key? key,
-    this.appcastConfig,
-    this.messages,
-    this.debugDisplayAlways = false,
-    this.debugDisplayOnce = false,
-    this.debugLogging = false,
-    Duration? durationToAlertAgain = const Duration(days: 3),
-    this.onIgnore,
-    this.onLater,
-    this.onUpdate,
-    this.shouldPopScope,
-    this.willDisplayUpgrade,
-    this.client,
-    this.showIgnore,
-    this.showLater,
-    this.showReleaseNotes,
-    this.canDismissDialog,
-    this.countryCode,
-    this.minAppVersion,
-    this.dialogStyle = UpgradeDialogStyle.material,
-  }) : super(key: key) {
-    if (appcastConfig != null) {
-      Upgrader().appcastConfig = appcastConfig;
-    }
-    if (messages != null) {
-      Upgrader().messages = messages;
-    }
-    if (client != null) {
-      Upgrader().client = client;
-    }
-    if (debugDisplayAlways != null) {
-      Upgrader().debugDisplayAlways = debugDisplayAlways!;
-    }
-    if (debugDisplayOnce != null) {
-      Upgrader().debugDisplayOnce = debugDisplayOnce!;
-    }
-    if (debugLogging != null) {
-      Upgrader().debugLogging = debugLogging!;
-    }
-    if (durationToAlertAgain != null) {
-      Upgrader().durationUntilAlertAgain = durationToAlertAgain;
-    }
-    if (onIgnore != null) {
-      Upgrader().onIgnore = onIgnore;
-    }
-    if (onLater != null) {
-      Upgrader().onLater = onLater;
-    }
-    if (onUpdate != null) {
-      Upgrader().onUpdate = onUpdate;
-    }
-    if (shouldPopScope != null) {
-      Upgrader().shouldPopScope = shouldPopScope;
-    }
-    if (willDisplayUpgrade != null) {
-      Upgrader().willDisplayUpgrade = willDisplayUpgrade;
-    }
-    if (showIgnore != null) {
-      Upgrader().showIgnore = showIgnore!;
-    }
-    if (showLater != null) {
-      Upgrader().showLater = showLater!;
-    }
-    if (showReleaseNotes != null) {
-      Upgrader().showReleaseNotes = showReleaseNotes!;
-    }
-    if (canDismissDialog != null) {
-      Upgrader().canDismissDialog = canDismissDialog!;
-    }
-    if (countryCode != null) {
-      Upgrader().countryCode = countryCode;
-    }
-    if (minAppVersion != null) {
-      Upgrader().minAppVersion = minAppVersion;
-    }
-    if (dialogStyle != null) {
-      Upgrader().dialogStyle = dialogStyle;
-    }
-  }
+  }) : super(key: key);
 
-  Widget? build(BuildContext context, UpgradeBaseState state) {
-    return null;
+  Widget build(BuildContext context, UpgradeBaseState state) {
+    return Container();
   }
 
   @override
@@ -163,12 +23,10 @@ class UpgradeBase extends StatefulWidget {
 }
 
 class UpgradeBaseState extends State<UpgradeBase> {
-  final _initialized = Upgrader().initialize();
-
-  Future<bool> get initialized => _initialized;
+  Future<bool> get initialized => widget.upgrader.initialize();
 
   @override
-  Widget build(BuildContext context) => widget.build(context, this)!;
+  Widget build(BuildContext context) => widget.build(context, this);
 
   void forceUpdateState() {
     setState(() {});

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -9,10 +9,7 @@ class UpgradeBase extends StatefulWidget {
   /// The upgraders used to configure the upgrade dialog.
   final Upgrader upgrader;
 
-  const UpgradeBase(
-    this.upgrader, {
-    Key? key,
-  }) : super(key: key);
+  const UpgradeBase(this.upgrader, {Key? key}) : super(key: key);
 
   Widget build(BuildContext context, UpgradeBaseState state) {
     return Container();

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -13,10 +13,12 @@ class UpgradeCard extends UpgradeBase {
   /// `EdgeInsets.all(4.0)`.
   final EdgeInsetsGeometry margin;
 
-  const UpgradeCard(Upgrader upgrader,
+  /// Creates a new [UpgradeCard].
+  UpgradeCard(Upgrader? upgrader,
       {Key? key, this.margin = const EdgeInsets.all(4.0)})
-      : super(upgrader, key: key);
+      : super(upgrader ?? Upgrader.sharedInstance, key: key);
 
+  /// Describes the part of the user interface represented by this widget.
   @override
   Widget build(BuildContext context, UpgradeBaseState state) {
     if (upgrader.debugLogging) {

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -57,7 +57,7 @@ class UpgradeCard extends UpgradeBase {
                       children: <Widget>[
                         Text(
                             Upgrader()
-                                    .messages!
+                                    .messages
                                     .message(UpgraderMessage.releaseNotes) ??
                                 '',
                             style:

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -1,9 +1,8 @@
 /*
- * Copyright (c) 2021 Larry Aasen. All rights reserved.
+ * Copyright (c) 2021-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';
-import 'package:http/http.dart' as http;
 import 'package:upgrader/upgrader.dart';
 
 /// A widget to display the upgrade card.
@@ -14,48 +13,13 @@ class UpgradeCard extends UpgradeBase {
   /// `EdgeInsets.all(4.0)`.
   final EdgeInsetsGeometry margin;
 
-  UpgradeCard({
-    this.margin = const EdgeInsets.all(4.0),
-    Key? key,
-    AppcastConfiguration? appcastConfig,
-    UpgraderMessages? messages,
-    bool? debugDisplayAlways,
-    bool? debugDisplayOnce,
-    bool? debugLogging,
-    Duration? durationToAlertAgain,
-    BoolCallback? onIgnore,
-    BoolCallback? onLater,
-    BoolCallback? onUpdate,
-    VoidBoolCallback? willDisplayUpgrade,
-    http.Client? client,
-    bool? showIgnore,
-    bool? showLater,
-    bool? showReleaseNotes,
-    String? countryCode,
-    String? minAppVersion,
-  }) : super(
-          key: key,
-          appcastConfig: appcastConfig,
-          messages: messages,
-          debugDisplayAlways: debugDisplayAlways,
-          debugDisplayOnce: debugDisplayOnce,
-          debugLogging: debugLogging,
-          durationToAlertAgain: durationToAlertAgain,
-          onIgnore: onIgnore,
-          onLater: onLater,
-          onUpdate: onUpdate,
-          willDisplayUpgrade: willDisplayUpgrade,
-          client: client,
-          showIgnore: showIgnore,
-          showLater: showLater,
-          showReleaseNotes: showReleaseNotes,
-          countryCode: countryCode,
-          minAppVersion: minAppVersion,
-        );
+  const UpgradeCard(Upgrader upgrader,
+      {Key? key, this.margin = const EdgeInsets.all(4.0)})
+      : super(upgrader, key: key);
 
   @override
   Widget build(BuildContext context, UpgradeBaseState state) {
-    if (Upgrader().debugLogging) {
+    if (upgrader.debugLogging) {
       print('UpgradeCard: build UpgradeCard');
     }
 
@@ -65,14 +29,13 @@ class UpgradeCard extends UpgradeBase {
           if (processed.connectionState == ConnectionState.done &&
               processed.data != null &&
               processed.data!) {
-            assert(Upgrader().messages != null);
-            if (Upgrader().shouldDisplayUpgrade()) {
-              final title = Upgrader().messages!.message(UpgraderMessage.title);
-              final message = Upgrader().message();
-              final releaseNotes = Upgrader().releaseNotes;
+            if (upgrader.shouldDisplayUpgrade()) {
+              final title = upgrader.messages.message(UpgraderMessage.title);
+              final message = upgrader.message();
+              final releaseNotes = upgrader.releaseNotes;
               final shouldDisplayReleaseNotes =
-                  Upgrader().shouldDisplayReleaseNotes();
-              if (Upgrader().debugLogging) {
+                  upgrader.shouldDisplayReleaseNotes();
+              if (upgrader.debugLogging) {
                 print('UpgradeCard: will display');
                 print('UpgradeCard: showDialog title: $title');
                 print('UpgradeCard: showDialog message: $message');
@@ -114,52 +77,51 @@ class UpgradeCard extends UpgradeBase {
                           Text(message),
                           Padding(
                               padding: const EdgeInsets.only(top: 15.0),
-                              child: Text(Upgrader()
-                                      .messages!
+                              child: Text(upgrader.messages
                                       .message(UpgraderMessage.prompt) ??
                                   '')),
                           if (notes != null) notes,
                         ],
                       ),
                       actions: <Widget>[
-                        if (Upgrader().showIgnore)
+                        if (upgrader.showIgnore)
                           TextButton(
-                              child: Text(Upgrader().messages!.message(
+                              child: Text(upgrader.messages.message(
                                       UpgraderMessage.buttonTitleIgnore) ??
                                   ''),
                               onPressed: () {
                                 // Save the date/time as the last time alerted.
-                                Upgrader().saveLastAlerted();
+                                upgrader.saveLastAlerted();
 
-                                Upgrader().onUserIgnored(context, false);
+                                upgrader.onUserIgnored(context, false);
                                 state.forceUpdateState();
                               }),
-                        if (Upgrader().showLater)
+                        if (upgrader.showLater)
                           TextButton(
-                              child: Text(Upgrader().messages!.message(
+                              child: Text(upgrader.messages.message(
                                       UpgraderMessage.buttonTitleLater) ??
                                   ''),
                               onPressed: () {
                                 // Save the date/time as the last time alerted.
-                                Upgrader().saveLastAlerted();
+                                upgrader.saveLastAlerted();
 
-                                Upgrader().onUserLater(context, false);
+                                upgrader.onUserLater(context, false);
                                 state.forceUpdateState();
                               }),
                         TextButton(
-                            child: Text(Upgrader().messages!.message(
+                            child: Text(upgrader.messages.message(
                                     UpgraderMessage.buttonTitleUpdate) ??
                                 ''),
                             onPressed: () {
                               // Save the date/time as the last time alerted.
-                              Upgrader().saveLastAlerted();
+                              upgrader.saveLastAlerted();
 
-                              Upgrader().onUserUpdated(context, false);
+                              upgrader.onUserUpdated(context, false);
                               state.forceUpdateState();
                             }),
                       ]));
             } else {
-              if (Upgrader().debugLogging) {
+              if (upgrader.debugLogging) {
                 print('UpgradeCard: will not display');
               }
             }

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -14,8 +14,8 @@ class UpgradeCard extends UpgradeBase {
   final EdgeInsetsGeometry margin;
 
   /// Creates a new [UpgradeCard].
-  UpgradeCard(Upgrader? upgrader,
-      {Key? key, this.margin = const EdgeInsets.all(4.0)})
+  UpgradeCard(
+      {Key? key, Upgrader? upgrader, this.margin = const EdgeInsets.all(4.0)})
       : super(upgrader ?? Upgrader.sharedInstance, key: key);
 
   /// Describes the part of the user interface represented by this widget.

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -25,6 +25,14 @@ typedef BoolCallback = bool Function();
 /// Signature of callbacks that have a bool argument and no return.
 typedef VoidBoolCallback = void Function(bool value);
 
+/// Signature of callback for willDisplayUpgrade. Includes display,
+/// minAppVersion, installedVersion, and appStoreVersion.
+typedef WillDisplayUpgradeCallback = void Function(
+    {required bool display,
+    String? minAppVersion,
+    String? installedVersion,
+    String? appStoreVersion});
+
 /// There are two different dialog styles: Cupertino and Material
 enum UpgradeDialogStyle { cupertino, material }
 
@@ -117,7 +125,7 @@ class Upgrader {
   /// displayed. The [value] parameter will be true when it should be displayed,
   /// and false when it should not be displayed. One good use for this callback
   /// is logging metrics for your app.
-  VoidBoolCallback? willDisplayUpgrade;
+  WillDisplayUpgradeCallback? willDisplayUpgrade;
 
   /// The target operating system.
   final String operatingSystem = UpgradeIO.operatingSystem;
@@ -418,10 +426,16 @@ class Upgrader {
     if (debugLogging) {
       print('upgrader: shouldDisplayUpgrade: $rv');
     }
+
     // Call the [willDisplayUpgrade] callback when available.
     if (willDisplayUpgrade != null) {
-      willDisplayUpgrade!(rv);
+      willDisplayUpgrade!(
+          display: rv,
+          minAppVersion: minAppVersion,
+          installedVersion: _installedVersion,
+          appStoreVersion: _appStoreVersion);
     }
+
     return rv;
   }
 

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -664,7 +664,7 @@ class Upgrader {
     }
 
     if (shouldPop) {
-      _pop(context);
+      popNavigator(context);
     }
   }
 
@@ -682,7 +682,7 @@ class Upgrader {
     if (doProcess) {}
 
     if (shouldPop) {
-      _pop(context);
+      popNavigator(context);
     }
   }
 
@@ -702,7 +702,7 @@ class Upgrader {
     }
 
     if (shouldPop) {
-      _pop(context);
+      popNavigator(context);
     }
   }
 
@@ -715,7 +715,7 @@ class Upgrader {
     return;
   }
 
-  void _pop(BuildContext context) {
+  void popNavigator(BuildContext context) {
     Navigator.of(context).pop();
     _displayed = false;
   }

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Larry Aasen. All rights reserved.
+ * Copyright (c) 2018-2022 Larry Aasen. All rights reserved.
  */
 
 import 'dart:async';
@@ -43,35 +43,43 @@ class AppcastConfiguration {
 
 /// A singleton class to configure the upgrade dialog.
 class Upgrader {
-  static Upgrader _singleton = Upgrader._internal();
+  /// Provide an Appcast that can be replaced for mock testing.
+  final Appcast? appcast;
 
   /// The appcast configuration ([AppcastConfiguration]) used by [Appcast].
   /// When an appcast is configured for iOS, the iTunes lookup is not used.
-  AppcastConfiguration? appcastConfig;
+  final AppcastConfiguration? appcastConfig;
 
-  /// Provide an Appcast that can be replaced for mock testing.
-  Appcast? appcast;
+  /// Can alert dialog be dismissed on tap outside of the alert dialog. Not used by [UpgradeCard]. (default: false)
+  bool canDismissDialog;
 
   /// Provide an HTTP Client that can be replaced for mock testing.
-  http.Client? client = http.Client();
+  final http.Client client;
 
-  /// Duration until alerting user again
-  Duration durationUntilAlertAgain = const Duration(days: 3);
+  /// The country code that will override the system locale. Optional. Used only for iOS.
+  final String? countryCode;
 
   /// For debugging, always force the upgrade to be available.
-  bool debugDisplayAlways = false;
+  bool debugDisplayAlways;
 
   /// For debugging, display the upgrade at least once once.
-  bool debugDisplayOnce = false;
+  bool debugDisplayOnce;
 
   /// Enable print statements for debugging.
-  bool debugLogging = false;
+  bool debugLogging;
+
+  /// The upgrade dialog style. Used only on UpgradeAlert. (default: material)
+  UpgradeDialogStyle dialogStyle;
+
+  /// Duration until alerting user again
+  final Duration durationUntilAlertAgain;
 
   /// The localized messages used for display in upgrader.
-  UpgraderMessages? messages;
+  UpgraderMessages messages;
 
-  final notInitializedExceptionMessage =
-      'initialize() not called. Must be called first.';
+  /// The minimum app version supported by this app. Earlier versions of this app
+  /// will be forced to update to the current version. Optional.
+  String? minAppVersion;
 
   /// Called when the ignore button is tapped or otherwise activated.
   /// Return false when the default behavior should not execute.
@@ -85,10 +93,22 @@ class Upgrader {
   /// Return false when the default behavior should not execute.
   BoolCallback? onUpdate;
 
+  /// The target platform.
+  final TargetPlatform platform;
+
   /// Called when the user taps outside of the dialog and [canDismissDialog]
   /// is false. Also called when the back button is pressed. Return true for
   /// the screen to be popped. Not used by [UpgradeCard].
   BoolCallback? shouldPopScope;
+
+  /// Hide or show Ignore button on dialog (default: true)
+  bool showIgnore;
+
+  /// Hide or show Later button on dialog (default: true)
+  bool showLater;
+
+  /// Hide or show release notes (default: true)
+  bool showReleaseNotes;
 
   /// Called when [Upgrader] determines that an upgrade may or may not be
   /// displayed. The [value] parameter will be true when it should be displayed,
@@ -96,33 +116,8 @@ class Upgrader {
   /// is logging metrics for your app.
   VoidBoolCallback? willDisplayUpgrade;
 
-  /// Hide or show Ignore button on dialog (default: true)
-  bool showIgnore = true;
-
-  /// Hide or show Later button on dialog (default: true)
-  bool showLater = true;
-
-  /// Hide or show release notes (default: true)
-  bool showReleaseNotes = true;
-
-  /// Can alert dialog be dismissed on tap outside of the alert dialog. Not used by [UpgradeCard]. (default: false)
-  bool canDismissDialog = false;
-
-  /// The country code that will override the system locale. Optional. Used only for iOS.
-  String? countryCode;
-
-  /// The minimum app version supported by this app. Earlier versions of this app
-  /// will be forced to update to the current version. Optional.
-  String? minAppVersion;
-
-  /// The upgrade dialog style. Optional. Used only on UpgradeAlert. (default: material)
-  UpgradeDialogStyle? dialogStyle = UpgradeDialogStyle.material;
-
-  /// The target platform.
-  TargetPlatform platform = defaultTargetPlatform;
-
   /// The target operating system.
-  String operatingSystem = UpgradeIO.operatingSystem;
+  final String operatingSystem = UpgradeIO.operatingSystem;
 
   bool _displayed = false;
   bool _initCalled = false;
@@ -139,11 +134,36 @@ class Upgrader {
   bool _hasAlerted = false;
   bool _isCriticalUpdate = false;
 
-  factory Upgrader() {
-    return _singleton;
-  }
+  final notInitializedExceptionMessage =
+      'initialize() not called. Must be called first.';
 
-  Upgrader._internal();
+  Upgrader({
+    this.appcastConfig,
+    this.appcast,
+    UpgraderMessages? messages,
+    this.debugDisplayAlways = false,
+    this.debugDisplayOnce = false,
+    this.debugLogging = false,
+    this.durationUntilAlertAgain = const Duration(days: 3),
+    this.onIgnore,
+    this.onLater,
+    this.onUpdate,
+    this.shouldPopScope,
+    this.willDisplayUpgrade,
+    http.Client? client,
+    this.showIgnore = true,
+    this.showLater = true,
+    this.showReleaseNotes = true,
+    this.canDismissDialog = false,
+    this.countryCode,
+    this.minAppVersion,
+    this.dialogStyle = UpgradeDialogStyle.material,
+    TargetPlatform? platform,
+  })  : client = client ?? http.Client(),
+        messages = messages ?? UpgraderMessages(),
+        platform = platform ?? defaultTargetPlatform {
+    print("upgrader: instantiated."); // TODO: remove this!
+  }
 
   void installPackageInfo({PackageInfo? packageInfo}) {
     _packageInfo = packageInfo;
@@ -165,11 +185,10 @@ class Upgrader {
 
     _initCalled = true;
 
-    messages ??= UpgraderMessages();
-    if (messages!.languageCode.isEmpty) {
+    if (messages.languageCode.isEmpty) {
       print('upgrader: error -> languageCode is empty');
     } else if (debugLogging) {
-      print('upgrader: languageCode: ${messages!.languageCode}');
+      print('upgrader: languageCode: ${messages.languageCode}');
     }
 
     await _getSavedPrefs();
@@ -329,7 +348,7 @@ class Upgrader {
   String? get releaseNotes => _releaseNotes;
 
   String message() {
-    var msg = messages!.message(UpgraderMessage.body)!;
+    var msg = messages.message(UpgraderMessage.body)!;
     msg = msg.replaceAll('{{appName}}', appName());
     msg = msg.replaceAll(
         '{{currentAppStoreVersion}}', currentAppStoreVersion() ?? '');
@@ -351,7 +370,7 @@ class Upgrader {
         Future.delayed(const Duration(milliseconds: 0), () {
           _showDialog(
               context: context,
-              title: messages!.message(UpgraderMessage.title),
+              title: messages.message(UpgraderMessage.title),
               message: message(),
               releaseNotes: shouldDisplayReleaseNotes() ? _releaseNotes : null,
               canDismissDialog: canDismissDialog);
@@ -561,22 +580,21 @@ class Upgrader {
           Text(message),
           Padding(
               padding: const EdgeInsets.only(top: 15.0),
-              child: Text(messages!.message(UpgraderMessage.prompt)!)),
+              child: Text(messages.message(UpgraderMessage.prompt)!)),
           if (notes != null) notes,
         ],
       )),
       actions: <Widget>[
         if (showIgnore)
           TextButton(
-              child:
-                  Text(messages!.message(UpgraderMessage.buttonTitleIgnore)!),
+              child: Text(messages.message(UpgraderMessage.buttonTitleIgnore)!),
               onPressed: () => onUserIgnored(context, true)),
         if (showLater)
           TextButton(
-              child: Text(messages!.message(UpgraderMessage.buttonTitleLater)!),
+              child: Text(messages.message(UpgraderMessage.buttonTitleLater)!),
               onPressed: () => onUserLater(context, true)),
         TextButton(
-            child: Text(messages!.message(UpgraderMessage.buttonTitleUpdate)!),
+            child: Text(messages.message(UpgraderMessage.buttonTitleUpdate)!),
             onPressed: () => onUserUpdated(context, !blocked())),
       ],
     );
@@ -609,23 +627,22 @@ class Upgrader {
           Text(message),
           Padding(
               padding: const EdgeInsets.only(top: 15.0),
-              child: Text(messages!.message(UpgraderMessage.prompt)!)),
+              child: Text(messages.message(UpgraderMessage.prompt)!)),
           if (notes != null) notes,
         ],
       ),
       actions: <Widget>[
         if (showIgnore)
           CupertinoDialogAction(
-              child:
-                  Text(messages!.message(UpgraderMessage.buttonTitleIgnore)!),
+              child: Text(messages.message(UpgraderMessage.buttonTitleIgnore)!),
               onPressed: () => onUserIgnored(context, true)),
         if (showLater)
           CupertinoDialogAction(
-              child: Text(messages!.message(UpgraderMessage.buttonTitleLater)!),
+              child: Text(messages.message(UpgraderMessage.buttonTitleLater)!),
               onPressed: () => onUserLater(context, true)),
         CupertinoDialogAction(
             isDefaultAction: true,
-            child: Text(messages!.message(UpgraderMessage.buttonTitleUpdate)!),
+            child: Text(messages.message(UpgraderMessage.buttonTitleUpdate)!),
             onPressed: () => onUserUpdated(context, !blocked())),
       ],
     );
@@ -689,21 +706,13 @@ class Upgrader {
     }
   }
 
-  Future<bool> clearSavedSettings() async {
+  static Future<void> clearSavedSettings() async {
     var prefs = await SharedPreferences.getInstance();
     await prefs.remove('userIgnoredVersion');
     await prefs.remove('lastTimeAlerted');
     await prefs.remove('lastVersionAlerted');
 
-    _userIgnoredVersion = null;
-    _lastTimeAlerted = null;
-    _lastVersionAlerted = null;
-
-    return true;
-  }
-
-  static void resetSingleton() {
-    _singleton = Upgrader._internal();
+    return;
   }
 
   void _pop(BuildContext context) {
@@ -757,9 +766,9 @@ class Upgrader {
       print('upgrader: launching: $_appStoreListingURL');
     }
 
-    if (await canLaunch(_appStoreListingURL!)) {
+    if (await canLaunchUrl(Uri.parse(_appStoreListingURL!))) {
       try {
-        await launch(_appStoreListingURL!);
+        await launchUrl(Uri.parse(_appStoreListingURL!));
       } catch (e) {
         if (debugLogging) {
           print('upgrader: launch to app store failed: $e');

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -580,7 +580,7 @@ class Upgrader {
             mainAxisSize: MainAxisSize.min,
             crossAxisAlignment: CrossAxisAlignment.start,
             children: <Widget>[
-              Text(messages!.message(UpgraderMessage.releaseNotes)!,
+              Text(messages.message(UpgraderMessage.releaseNotes)!,
                   style: const TextStyle(fontWeight: FontWeight.bold)),
               Text(
                 releaseNotes,
@@ -628,7 +628,7 @@ class Upgrader {
           padding: const EdgeInsets.only(top: 15.0),
           child: Column(
             children: <Widget>[
-              Text(messages!.message(UpgraderMessage.releaseNotes)!,
+              Text(messages.message(UpgraderMessage.releaseNotes)!,
                   style: const TextStyle(fontWeight: FontWeight.bold)),
               Text(
                 releaseNotes,

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -41,7 +41,10 @@ class AppcastConfiguration {
   });
 }
 
-/// A singleton class to configure the upgrade dialog.
+/// Creates a shared instance of [Upgrader].
+late Upgrader _sharedInstance = Upgrader();
+
+/// A class to configure the upgrade dialog.
 class Upgrader {
   /// Provide an Appcast that can be replaced for mock testing.
   final Appcast? appcast;
@@ -164,6 +167,9 @@ class Upgrader {
         platform = platform ?? defaultTargetPlatform {
     print("upgrader: instantiated."); // TODO: remove this!
   }
+
+  /// A shared instance of [Upgrader].
+  static get sharedInstance => _sharedInstance;
 
   void installPackageInfo({PackageInfo? packageInfo}) {
     _packageInfo = packageInfo;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 4.0.0-alpha.1
+version: 4.0.0-alpha.2
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 4.0.0-alpha.2
+version: 4.0.0-alpha.3
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 4.0.0-alpha.3
+version: 4.0.0-alpha.4
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 3.14.0
+version: 4.0.0-pre1
 homepage: https://github.com/larryaasen/upgrader
 
 environment:
@@ -27,7 +27,7 @@ dependencies:
   shared_preferences: ^2.0.3
 
   # From Flutter Team: A Flutter plugin for launching a URL in the mobile platform.
-  url_launcher: ^6.0.2
+  url_launcher: ^6.1.0
 
   # A dart library for comparing and incrementing version numbers with Semantic Versioning.
   version:  ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 4.0.0-alpha.4
+version: 4.0.0
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 4.0.0-pre1
+version: 4.0.0-alpha.1
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -48,6 +48,14 @@ void main() {
     await preferences.clear();
   });
 
+  testWidgets('test Upgrader sharedInstance', (WidgetTester tester) async {
+    final upgrader1 = Upgrader.sharedInstance;
+    expect(upgrader1, isNotNull);
+    final upgrader2 = Upgrader.sharedInstance;
+    expect(upgrader2, isNotNull);
+    expect(upgrader1 == upgrader2, isTrue);
+  }, skip: false);
+
   testWidgets('test Upgrader class', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
     final upgrader = Upgrader(platform: TargetPlatform.iOS, client: client);
@@ -644,7 +652,7 @@ void main() {
           Upgrader(durationUntilAlertAgain: const Duration(seconds: 0));
       expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
 
-      UpgradeAlert(upgrader);
+      UpgradeAlert(upgrader: upgrader);
       expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
 
       UpgradeCard(upgrader);
@@ -666,12 +674,12 @@ void main() {
     test('durationUntilAlertAgain alert is valid', () async {
       final upgrader =
           Upgrader(durationUntilAlertAgain: const Duration(days: 3));
-      UpgradeAlert(upgrader);
+      UpgradeAlert(upgrader: upgrader);
       expect(upgrader.durationUntilAlertAgain, const Duration(days: 3));
 
       final upgrader2 =
           Upgrader(durationUntilAlertAgain: const Duration(days: 10));
-      UpgradeAlert(upgrader2);
+      UpgradeAlert(upgrader: upgrader2);
       expect(upgrader2.durationUntilAlertAgain, const Duration(days: 10));
     }, skip: false);
   });
@@ -828,7 +836,8 @@ class _MyWidget extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Upgrader test'),
         ),
-        body: UpgradeAlert(upgrader,
+        body: UpgradeAlert(
+            upgrader: upgrader,
             child: Column(
               children: const <Widget>[Text('Upgrading')],
             )),

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -130,17 +130,17 @@ void main() {
 
     expect(upgrader.messages, isNotNull);
 
-    expect(upgrader.messages!.buttonTitleIgnore, 'IGNORE');
-    expect(upgrader.messages!.buttonTitleLater, 'LATER');
-    expect(upgrader.messages!.buttonTitleUpdate, 'UPDATE NOW');
-    expect(upgrader.messages!.releaseNotes, 'Release Notes');
+    expect(upgrader.messages.buttonTitleIgnore, 'IGNORE');
+    expect(upgrader.messages.buttonTitleLater, 'LATER');
+    expect(upgrader.messages.buttonTitleUpdate, 'UPDATE NOW');
+    expect(upgrader.messages.releaseNotes, 'Release Notes');
 
     upgrader.messages = MyUpgraderMessages();
 
-    expect(upgrader.messages!.buttonTitleIgnore, 'aaa');
-    expect(upgrader.messages!.buttonTitleLater, 'bbb');
-    expect(upgrader.messages!.buttonTitleUpdate, 'ccc');
-    expect(upgrader.messages!.releaseNotes, 'ddd');
+    expect(upgrader.messages.buttonTitleIgnore, 'aaa');
+    expect(upgrader.messages.buttonTitleLater, 'bbb');
+    expect(upgrader.messages.buttonTitleUpdate, 'ccc');
+    expect(upgrader.messages.releaseNotes, 'ddd');
 
     await tester.pumpWidget(_MyWidget(upgrader: upgrader));
 
@@ -155,21 +155,21 @@ void main() {
 
     expect(find.text(upgrader.messages.title), findsOneWidget);
     expect(find.text(upgrader.message()), findsOneWidget);
-    expect(find.text(upgrader.messages!.releaseNotes), findsOneWidget);
+    expect(find.text(upgrader.messages.releaseNotes), findsOneWidget);
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
     expect(find.text(upgrader.messages.prompt), findsOneWidget);
     expect(find.byType(TextButton), findsNWidgets(3));
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsOneWidget);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsOneWidget);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsOneWidget);
-    expect(find.text(upgrader.messages!.releaseNotes), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);
+    expect(find.text(upgrader.messages.releaseNotes), findsOneWidget);
 
     await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsNothing);
-    expect(find.text(upgrader.messages!.releaseNotes), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsNothing);
+    expect(find.text(upgrader.messages.releaseNotes), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   }, skip: false);
@@ -231,7 +231,7 @@ void main() {
 
     expect(find.text(upgrader.messages.title), findsOneWidget);
     expect(find.text(upgrader.message()), findsOneWidget);
-    expect(find.text(upgrader.messages!.releaseNotes), findsOneWidget);
+    expect(find.text(upgrader.messages.releaseNotes), findsOneWidget);
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
     expect(find.text(upgrader.messages.prompt), findsOneWidget);
     expect(find.byType(CupertinoDialogAction), findsNWidgets(3));
@@ -401,7 +401,7 @@ void main() {
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
-    expect(find.text(upgrader.messages!.releaseNotes), findsOneWidget);
+    expect(find.text(upgrader.messages.releaseNotes), findsOneWidget);
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
     await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -655,19 +655,19 @@ void main() {
       UpgradeAlert(upgrader: upgrader);
       expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
 
-      UpgradeCard(upgrader);
+      UpgradeCard(upgrader: upgrader);
       expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
     }, skip: false);
 
     test('durationUntilAlertAgain card is valid', () async {
       final upgrader =
           Upgrader(durationUntilAlertAgain: const Duration(days: 3));
-      UpgradeCard(upgrader);
+      UpgradeCard(upgrader: upgrader);
       expect(upgrader.durationUntilAlertAgain, const Duration(days: 3));
 
       final upgrader2 =
           Upgrader(durationUntilAlertAgain: const Duration(days: 10));
-      final _ = UpgradeCard(upgrader2);
+      final _ = UpgradeCard(upgrader: upgrader2);
       expect(upgrader2.durationUntilAlertAgain, const Duration(days: 10));
     }, skip: false);
 
@@ -859,7 +859,7 @@ class _MyWidgetCard extends StatelessWidget {
           title: const Text('Upgrader test'),
         ),
         body: Column(
-          children: <Widget>[UpgradeCard(upgrader)],
+          children: <Widget>[UpgradeCard(upgrader: upgrader)],
         ),
       ),
     );

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Larry Aasen. All rights reserved.
+ * Copyright (c) 2018-2022 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/cupertino.dart';
@@ -698,8 +698,15 @@ void main() {
 
       // Test the willDisplayUpgrade callback
       var notCalled = true;
-      upgrader.willDisplayUpgrade = (bool value) {
-        expect(value, false);
+      upgrader.willDisplayUpgrade = (
+          {required bool display,
+          String? minAppVersion,
+          String? installedVersion,
+          String? appStoreVersion}) {
+        expect(display, false);
+        expect(minAppVersion, isNull);
+        expect(installedVersion, isNull);
+        expect(appStoreVersion, isNull);
         notCalled = false;
       };
       expect(upgrader.shouldDisplayUpgrade(), false);
@@ -707,8 +714,15 @@ void main() {
 
       upgrader.debugDisplayAlways = true;
       notCalled = true;
-      upgrader.willDisplayUpgrade = (bool value) {
-        expect(value, true);
+      upgrader.willDisplayUpgrade = (
+          {required bool display,
+          String? minAppVersion,
+          String? installedVersion,
+          String? appStoreVersion}) {
+        expect(display, true);
+        expect(minAppVersion, isNull);
+        expect(installedVersion, isNull);
+        expect(appStoreVersion, isNull);
         notCalled = false;
       };
       expect(upgrader.shouldDisplayUpgrade(), true);
@@ -731,10 +745,24 @@ void main() {
         );
 
       await upgrader.initialize();
+      var notCalled = true;
+      upgrader.willDisplayUpgrade = (
+          {required bool display,
+          String? minAppVersion,
+          String? installedVersion,
+          String? appStoreVersion}) {
+        expect(display, true);
+        expect(minAppVersion, '2.0.0');
+        expect(upgrader.minAppVersion, '2.0.0');
+        expect(installedVersion, '1.9.6');
+        expect(appStoreVersion, '5.6');
+        notCalled = false;
+      };
 
       final shouldDisplayUpgrade = upgrader.shouldDisplayUpgrade();
 
       expect(shouldDisplayUpgrade, isTrue);
+      expect(notCalled, false);
     }, skip: false);
 
     test('should return true when bestItem has critical update', () async {

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -27,8 +27,6 @@ void main() {
   const kEmptyPreferences = <String, dynamic>{};
 
   setUp(() async {
-    Upgrader.resetSingleton();
-
     // This idea to mock the shared preferences taken from:
     /// https://github.com/flutter/plugins/blob/master/packages/shared_preferences/test/shared_preferences_test.dart
     sharedPrefsChannel.setMockMethodCallHandler((MethodCall methodCall) async {
@@ -43,7 +41,7 @@ void main() {
       return null;
     });
     preferences = await SharedPreferences.getInstance();
-    await Upgrader().clearSavedSettings();
+    await Upgrader.clearSavedSettings();
   });
 
   tearDown(() async {
@@ -52,9 +50,7 @@ void main() {
 
   testWidgets('test Upgrader class', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
+    final upgrader = Upgrader(platform: TargetPlatform.iOS, client: client);
 
     expect(tester.takeException(), null);
     await tester.pumpAndSettle();
@@ -95,10 +91,8 @@ void main() {
 
   testWidgets('test UpgradeWidget', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -128,17 +122,17 @@ void main() {
 
     expect(upgrader.messages, isNotNull);
 
-    expect(upgrader.messages!.buttonTitleIgnore, 'IGNORE');
-    expect(upgrader.messages!.buttonTitleLater, 'LATER');
-    expect(upgrader.messages!.buttonTitleUpdate, 'UPDATE NOW');
+    expect(upgrader.messages.buttonTitleIgnore, 'IGNORE');
+    expect(upgrader.messages.buttonTitleLater, 'LATER');
+    expect(upgrader.messages.buttonTitleUpdate, 'UPDATE NOW');
 
     upgrader.messages = MyUpgraderMessages();
 
-    expect(upgrader.messages!.buttonTitleIgnore, 'aaa');
-    expect(upgrader.messages!.buttonTitleLater, 'bbb');
-    expect(upgrader.messages!.buttonTitleUpdate, 'ccc');
+    expect(upgrader.messages.buttonTitleIgnore, 'aaa');
+    expect(upgrader.messages.buttonTitleLater, 'bbb');
+    expect(upgrader.messages.buttonTitleUpdate, 'ccc');
 
-    await tester.pumpWidget(const _MyWidget());
+    await tester.pumpWidget(_MyWidget(upgrader: upgrader));
 
     expect(find.text('Upgrader test'), findsOneWidget);
     expect(find.text('Upgrading'), findsOneWidget);
@@ -149,31 +143,29 @@ void main() {
 
     expect(upgrader.isTooSoon(), true);
 
-    expect(find.text(upgrader.messages!.title), findsOneWidget);
+    expect(find.text(upgrader.messages.title), findsOneWidget);
     expect(find.text(upgrader.message()), findsOneWidget);
     expect(find.text('Release Notes:'), findsOneWidget);
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
-    expect(find.text(upgrader.messages!.prompt), findsOneWidget);
+    expect(find.text(upgrader.messages.prompt), findsOneWidget);
     expect(find.byType(TextButton), findsNWidgets(3));
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsOneWidget);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsOneWidget);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);
 
-    await tester.tap(find.text(upgrader.messages!.buttonTitleUpdate));
+    await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   }, skip: false);
 
   testWidgets('test UpgradeWidget Cupertino', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -203,19 +195,18 @@ void main() {
 
     expect(upgrader.messages, isNotNull);
 
-    expect(upgrader.messages!.buttonTitleIgnore, 'IGNORE');
-    expect(upgrader.messages!.buttonTitleLater, 'LATER');
-    expect(upgrader.messages!.buttonTitleUpdate, 'UPDATE NOW');
+    expect(upgrader.messages.buttonTitleIgnore, 'IGNORE');
+    expect(upgrader.messages.buttonTitleLater, 'LATER');
+    expect(upgrader.messages.buttonTitleUpdate, 'UPDATE NOW');
 
     upgrader.messages = MyUpgraderMessages();
 
-    expect(upgrader.messages!.buttonTitleIgnore, 'aaa');
-    expect(upgrader.messages!.buttonTitleLater, 'bbb');
-    expect(upgrader.messages!.buttonTitleUpdate, 'ccc');
+    expect(upgrader.messages.buttonTitleIgnore, 'aaa');
+    expect(upgrader.messages.buttonTitleLater, 'bbb');
+    expect(upgrader.messages.buttonTitleUpdate, 'ccc');
+    upgrader.dialogStyle = UpgradeDialogStyle.cupertino;
 
-    await tester.pumpWidget(const _MyWidget(
-      dialogStyle: UpgradeDialogStyle.cupertino,
-    ));
+    await tester.pumpWidget(_MyWidget(upgrader: upgrader));
 
     expect(find.text('Upgrader test'), findsOneWidget);
     expect(find.text('Upgrading'), findsOneWidget);
@@ -226,29 +217,27 @@ void main() {
 
     expect(upgrader.isTooSoon(), true);
 
-    expect(find.text(upgrader.messages!.title), findsOneWidget);
+    expect(find.text(upgrader.messages.title), findsOneWidget);
     expect(find.text(upgrader.message()), findsOneWidget);
     expect(find.text('Release Notes:'), findsOneWidget);
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
-    expect(find.text(upgrader.messages!.prompt), findsOneWidget);
+    expect(find.text(upgrader.messages.prompt), findsOneWidget);
     expect(find.byType(CupertinoDialogAction), findsNWidgets(3));
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsOneWidget);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsOneWidget);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);
 
-    await tester.tap(find.text(upgrader.messages!.buttonTitleUpdate));
+    await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   }, skip: false);
   testWidgets('test UpgradeWidget ignore', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
+    final upgrader = Upgrader(platform: TargetPlatform.iOS, client: client);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -275,24 +264,22 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidget());
+    await tester.pumpWidget(_MyWidget(upgrader: upgrader));
 
     // Pump the UI so the upgrader can display its dialog
     await tester.pumpAndSettle();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.messages!.buttonTitleIgnore));
+    await tester.tap(find.text(upgrader.messages.buttonTitleIgnore));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   }, skip: false);
 
   testWidgets('test UpgradeWidget later', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
+    final upgrader = Upgrader(platform: TargetPlatform.iOS, client: client);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -319,24 +306,22 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidget());
+    await tester.pumpWidget(_MyWidget(upgrader: upgrader));
 
     // Pump the UI so the upgrader can display its dialog
     await tester.pumpAndSettle();
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.messages!.buttonTitleLater));
+    await tester.tap(find.text(upgrader.messages.buttonTitleLater));
     await tester.pumpAndSettle();
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
     expect(called, true);
     expect(notCalled, true);
   }, skip: false);
 
   testWidgets('test UpgradeWidget pop scope', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
+    final upgrader = Upgrader(platform: TargetPlatform.iOS, client: client);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -354,7 +339,7 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidget());
+    await tester.pumpWidget(_MyWidget(upgrader: upgrader));
 
     // Pump the UI so the upgrader can display its dialog
     await tester.pumpAndSettle();
@@ -363,16 +348,14 @@ void main() {
     // TODO: this test does not pop scope because there is no way to do that.
     // await tester.pageBack();
     // await tester.pumpAndSettle();
-    // expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
+    // expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
     expect(called, false);
   }, skip: false);
 
   testWidgets('test UpgradeWidget Card upgrade', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.client = client;
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -401,27 +384,25 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidgetCard());
+    await tester.pumpWidget(_MyWidgetCard(upgrader: upgrader));
 
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
     expect(find.text('Release Notes:'), findsOneWidget);
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
-    await tester.tap(find.text(upgrader.messages!.buttonTitleUpdate));
+    await tester.tap(find.text(upgrader.messages.buttonTitleUpdate));
     await tester.pumpAndSettle();
 
     expect(called, true);
     expect(notCalled, true);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsNothing);
   }, skip: false);
 
   testWidgets('test UpgradeWidget Card ignore', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -448,25 +429,23 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidgetCard());
+    await tester.pumpWidget(_MyWidgetCard(upgrader: upgrader));
 
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text(upgrader.messages!.buttonTitleIgnore));
+    await tester.tap(find.text(upgrader.messages.buttonTitleIgnore));
     await tester.pumpAndSettle();
 
     expect(called, true);
     expect(notCalled, true);
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
   }, skip: false);
 
   testWidgets('test UpgradeWidget Card later', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -493,25 +472,23 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidgetCard());
+    await tester.pumpWidget(_MyWidgetCard(upgrader: upgrader));
 
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    await tester.tap(find.text(upgrader.messages!.buttonTitleLater));
+    await tester.tap(find.text(upgrader.messages.buttonTitleLater));
     await tester.pumpAndSettle();
 
     expect(called, true);
     expect(notCalled, true);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
   }, skip: false);
 
   testWidgets('test upgrader minAppVersion', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
     upgrader.minAppVersion = '1.0.0';
 
     upgrader.installPackageInfo(
@@ -540,23 +517,21 @@ void main() {
 
     upgrader.minAppVersion = '1.0.0';
 
-    await tester.pumpWidget(const _MyWidgetCard());
+    await tester.pumpWidget(_MyWidgetCard(upgrader: upgrader));
 
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle(const Duration(milliseconds: 5000));
 
-    expect(find.text(upgrader.messages!.buttonTitleIgnore), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleLater), findsNothing);
-    expect(find.text(upgrader.messages!.buttonTitleUpdate), findsOneWidget);
+    expect(find.text(upgrader.messages.buttonTitleIgnore), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleLater), findsNothing);
+    expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);
   }, skip: false);
 
   testWidgets('test upgrader minAppVersion description android',
       (WidgetTester tester) async {
     final client = await MockPlayStoreSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.android;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.android, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -575,10 +550,8 @@ void main() {
     final client = MockITunesSearchClient.setupMockClient(
       description: 'Use this app. [:mav: 4.5.6]',
     );
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -594,11 +567,11 @@ void main() {
 
   testWidgets('test UpgradeWidget unknown app', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
-    final upgrader = Upgrader();
-    upgrader.platform = TargetPlatform.iOS;
-    upgrader.client = client;
-    upgrader.debugLogging = true;
-    upgrader.countryCode = 'IT';
+    final upgrader = Upgrader(
+        platform: TargetPlatform.iOS,
+        client: client,
+        debugLogging: true,
+        countryCode: 'IT');
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -625,12 +598,12 @@ void main() {
 
     expect(upgrader.isTooSoon(), false);
 
-    await tester.pumpWidget(const _MyWidgetCard());
+    await tester.pumpWidget(_MyWidgetCard(upgrader: upgrader));
 
     // Pump the UI so the upgrade card is displayed
     await tester.pumpAndSettle();
 
-    final laterButton = find.text(upgrader.messages!.buttonTitleLater);
+    final laterButton = find.text(upgrader.messages.buttonTitleLater);
     expect(laterButton, findsNothing);
 
     expect(called, false);
@@ -641,12 +614,12 @@ void main() {
     test('should use fake Appcast', () async {
       final fakeAppcast = FakeAppcast();
       final client = MockITunesSearchClient.setupMockClient();
-      final upgrader = Upgrader()
-        ..platform = TargetPlatform.iOS
-        ..client = client
-        ..appcastConfig = fakeAppcast.config
-        ..debugLogging = true
-        ..appcast = fakeAppcast
+      final upgrader = Upgrader(
+          platform: TargetPlatform.iOS,
+          client: client,
+          debugLogging: true,
+          appcastConfig: fakeAppcast.config,
+          appcast: fakeAppcast)
         ..installPackageInfo(
           packageInfo: PackageInfo(
             appName: 'Upgrader',
@@ -667,42 +640,47 @@ void main() {
     }, skip: false);
 
     test('durationUntilAlertAgain is 0 days', () async {
-      final upgrader = Upgrader();
-      upgrader.durationUntilAlertAgain = const Duration(seconds: 0);
+      final upgrader =
+          Upgrader(durationUntilAlertAgain: const Duration(seconds: 0));
       expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
 
-      final alert1 =
-          UpgradeAlert(durationToAlertAgain: const Duration(seconds: 0));
-      expect(alert1.durationToAlertAgain, const Duration(seconds: 0));
+      UpgradeAlert(upgrader);
+      expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
 
-      final card1 =
-          UpgradeCard(durationToAlertAgain: const Duration(seconds: 0));
-      expect(card1.durationToAlertAgain, const Duration(seconds: 0));
+      UpgradeCard(upgrader);
+      expect(upgrader.durationUntilAlertAgain, const Duration(seconds: 0));
     }, skip: false);
 
     test('durationUntilAlertAgain card is valid', () async {
-      final card1 = UpgradeCard();
-      expect(card1.durationToAlertAgain, const Duration(days: 3));
-      final card2 = UpgradeCard(durationToAlertAgain: const Duration(days: 10));
-      expect(card2.durationToAlertAgain, const Duration(days: 10));
+      final upgrader =
+          Upgrader(durationUntilAlertAgain: const Duration(days: 3));
+      UpgradeCard(upgrader);
+      expect(upgrader.durationUntilAlertAgain, const Duration(days: 3));
+
+      final upgrader2 =
+          Upgrader(durationUntilAlertAgain: const Duration(days: 10));
+      final _ = UpgradeCard(upgrader2);
+      expect(upgrader2.durationUntilAlertAgain, const Duration(days: 10));
     }, skip: false);
 
     test('durationUntilAlertAgain alert is valid', () async {
-      final alert1 = UpgradeAlert();
-      expect(alert1.durationToAlertAgain, const Duration(days: 3));
-      final alert2 =
-          UpgradeAlert(durationToAlertAgain: const Duration(days: 10));
-      expect(alert2.durationToAlertAgain, const Duration(days: 10));
+      final upgrader =
+          Upgrader(durationUntilAlertAgain: const Duration(days: 3));
+      UpgradeAlert(upgrader);
+      expect(upgrader.durationUntilAlertAgain, const Duration(days: 3));
+
+      final upgrader2 =
+          Upgrader(durationUntilAlertAgain: const Duration(days: 10));
+      UpgradeAlert(upgrader2);
+      expect(upgrader2.durationUntilAlertAgain, const Duration(days: 10));
     }, skip: false);
   });
 
   group('shouldDisplayUpgrade', () {
     test('should respect debugDisplayAlways property', () {
       final client = MockITunesSearchClient.setupMockClient();
-      final upgrader = Upgrader()
-        ..platform = TargetPlatform.iOS
-        ..client = client
-        ..debugLogging = true;
+      final upgrader = Upgrader(
+          platform: TargetPlatform.iOS, client: client, debugLogging: true);
 
       expect(upgrader.shouldDisplayUpgrade(), false);
       upgrader.debugDisplayAlways = true;
@@ -730,10 +708,10 @@ void main() {
     }, skip: false);
 
     test('should return true when version is below minAppVersion', () async {
-      final upgrader = Upgrader()
-        ..client = MockITunesSearchClient.setupMockClient()
-        ..platform = TargetPlatform.iOS
-        ..debugLogging = true
+      final upgrader = Upgrader(
+          debugLogging: true,
+          platform: TargetPlatform.iOS,
+          client: MockITunesSearchClient.setupMockClient())
         ..minAppVersion = '2.0.0'
         ..installPackageInfo(
           packageInfo: PackageInfo(
@@ -752,10 +730,10 @@ void main() {
     }, skip: false);
 
     test('should return true when bestItem has critical update', () async {
-      final upgrader = Upgrader()
-        ..client = MockITunesSearchClient.setupMockClient()
-        ..platform = TargetPlatform.iOS
-        ..debugLogging = true
+      final upgrader = Upgrader(
+          debugLogging: true,
+          platform: TargetPlatform.iOS,
+          client: MockITunesSearchClient.setupMockClient())
         ..installPackageInfo(
           packageInfo: PackageInfo(
             appName: 'Upgrader',
@@ -773,10 +751,10 @@ void main() {
     }, skip: false);
 
     test('packageInfo is empty', () async {
-      final upgrader = Upgrader()
-        ..client = MockITunesSearchClient.setupMockClient()
-        ..platform = TargetPlatform.iOS
-        ..debugLogging = true
+      final upgrader = Upgrader(
+          client: MockITunesSearchClient.setupMockClient(),
+          platform: TargetPlatform.iOS,
+          debugLogging: true)
         ..installPackageInfo(
           packageInfo: PackageInfo(
             appName: '',
@@ -839,11 +817,8 @@ void verifyMessages(UpgraderMessages messages, String code) {
 }
 
 class _MyWidget extends StatelessWidget {
-  final UpgradeDialogStyle dialogStyle;
-  const _MyWidget({
-    Key? key,
-    this.dialogStyle = UpgradeDialogStyle.material,
-  }) : super(key: key);
+  final Upgrader upgrader;
+  const _MyWidget({Key? key, required this.upgrader}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -853,10 +828,7 @@ class _MyWidget extends StatelessWidget {
         appBar: AppBar(
           title: const Text('Upgrader test'),
         ),
-        body: UpgradeAlert(
-            debugLogging: true,
-            dialogStyle: dialogStyle,
-            willDisplayUpgrade: (bool value) {},
+        body: UpgradeAlert(upgrader,
             child: Column(
               children: const <Widget>[Text('Upgrading')],
             )),
@@ -866,9 +838,8 @@ class _MyWidget extends StatelessWidget {
 }
 
 class _MyWidgetCard extends StatelessWidget {
-  const _MyWidgetCard({
-    Key? key,
-  }) : super(key: key);
+  final Upgrader upgrader;
+  const _MyWidgetCard({Key? key, required this.upgrader}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -879,12 +850,7 @@ class _MyWidgetCard extends StatelessWidget {
           title: const Text('Upgrader test'),
         ),
         body: Column(
-          children: <Widget>[
-            UpgradeCard(
-              debugLogging: true,
-              willDisplayUpgrade: (bool value) {},
-            )
-          ],
+          children: <Widget>[UpgradeCard(upgrader)],
         ),
       ),
     );


### PR DESCRIPTION
[BREAKING] No more singleton. This is a huge update to remove the use of a singleton for Upgrader. It is now a normal class that is passed to either UpgradeAlert or UpgradeCard. This makes it easy to subclass Upgrader and change its behavior. The parameters to UpgradeAlert and UpgradeCard have been removed, and can be set on Upgrader. See the various examples for more information.