### PR TITLE
Launch PlayStore/AppStore instead of launchUrl default webview

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -788,7 +788,7 @@ class Upgrader {
 
     if (await canLaunchUrl(Uri.parse(_appStoreListingURL!))) {
       try {
-        await launchUrl(Uri.parse(_appStoreListingURL!));
+        await launchUrl(Uri.parse(_appStoreListingURL!),mode: LaunchMode.externalNonBrowserApplication);
       } catch (e) {
         if (debugLogging) {
           print('upgrader: launch to app store failed: $e');


### PR DESCRIPTION
Can't update app in launchUrl default webview so changing default mode in launchUrl  to LaunchMode.externalNonBrowserApplication