### PR TITLE
Fix syntax error in Cupertino style dialog in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ class MyApp extends StatelessWidget {
 You can also display a Cupertino style dialog by using the `dialogStyle` parameter.
 ```dart
           body: UpgradeAlert(
-            Upgrader(dialogStyle: UpgradeDialogStyle.cupertino),
+            upgrader: Upgrader(dialogStyle: UpgradeDialogStyle.cupertino),
             child: Center(child: Text('Checking...')),
           )
 ```


### PR DESCRIPTION
UpgradeAlert requires `upgrader` as the named parameter instead of a direct argument.