### PR TITLE
<FIX> fixed launch url malfunction issue with IOS

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -3,6 +3,7 @@
  */
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -794,7 +795,7 @@ class Upgrader {
     if (await canLaunchUrl(Uri.parse(_appStoreListingURL!))) {
       try {
         await launchUrl(Uri.parse(_appStoreListingURL!),
-            mode: LaunchMode.externalNonBrowserApplication);
+            mode: Platform.isAndroid ? LaunchMode.externalNonBrowserApplication : LaunchMode.platformDefault);
       } catch (e) {
         if (debugLogging) {
           print('upgrader: launch to app store failed: $e');

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -3,7 +3,6 @@
  */
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
@@ -795,7 +794,7 @@ class Upgrader {
     if (await canLaunchUrl(Uri.parse(_appStoreListingURL!))) {
       try {
         await launchUrl(Uri.parse(_appStoreListingURL!),
-            mode: Platform.isAndroid
+            mode: UpgradeIO.isAndroid
                 ? LaunchMode.externalNonBrowserApplication
                 : LaunchMode.platformDefault);
       } catch (e) {

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -795,7 +795,9 @@ class Upgrader {
     if (await canLaunchUrl(Uri.parse(_appStoreListingURL!))) {
       try {
         await launchUrl(Uri.parse(_appStoreListingURL!),
-            mode: Platform.isAndroid ? LaunchMode.externalNonBrowserApplication : LaunchMode.platformDefault);
+            mode: Platform.isAndroid
+                ? LaunchMode.externalNonBrowserApplication
+                : LaunchMode.platformDefault);
       } catch (e) {
         if (debugLogging) {
           print('upgrader: launch to app store failed: $e');


### PR DESCRIPTION
I was unable to open App Store URL with LaunchMode.externalNonBrowserApplication. Since the code update here with LaunchMode was to aid Android OS, I changed the code so that only Android will launch the URL with LaunchMode.externalNonBrowserApplication while others kept their LaunchMode.platformDefault.