### PR TITLE
version fixed from 4.1.0 to 4.0.1 to ensure backward compatibility

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   # From fluttercommunity.dev: Get current device information from within the Flutter application.
-  device_info_plus: ">=3.2.0 <4.1.0"
+  device_info_plus: ">=3.2.0 <4.0.1"
 
   # From Dart Team: A composable, Future-based library for making HTTP requests.
   http: ^0.13.0


### PR DESCRIPTION
Device_info_plus's latest version is 4.0.2, and they introduced some new parameters to WindowsDeviceInfo. Due to which the code was breaking. So changed the maximum version from 4.1.0 to 4.0.1