### PR TITLE
<FIX> disabled cupertino dialog's action scroll

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -642,7 +642,12 @@ class Upgrader {
             ],
           ));
     }
+    var actionScrollController = ScrollController();
+    actionScrollController.addListener(() {
+      actionScrollController.jumpTo(0);
+    });
     return CupertinoAlertDialog(
+      actionScrollController: actionScrollController,
       title: Text(title),
       content: Column(
         // mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
Cupertino version of UpgradeAlert had an issue where the actions(Later, Ignore, Update Now) may be scrolled. This is an odd UI behavior and thus disabled it.