### PR TITLE
Flutter 3.0.1 min

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['3.0.1', '3.2.0', '3.3.6']
+        flutter-version: ['3.0.1', '3.3.0', '3.3.7']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        flutter-version: ['2.5.0', '3.0.0', '3.3.6']
+        flutter-version: ['3.0.1', '3.2.0', '3.3.6']
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [5.0.0-alpha.1]
+
+- Updated to Flutter 3.01 and Dart 2.17.1.
+- Updated all package dependencies to their latest version.
+- Fixed a few warnings.
+
 ## [4.11.0]
 
 - Updated package dependencies:

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/example/lib/generated_plugin_registrant.dart
+++ b/example/lib/generated_plugin_registrant.dart
@@ -6,8 +6,6 @@
 // ignore_for_file: lines_longer_than_80_chars
 // ignore_for_file: depend_on_referenced_packages
 
-import 'package:device_info_plus_web/device_info_plus_web.dart';
-import 'package:package_info_plus_web/package_info_plus_web.dart';
 import 'package:shared_preferences_web/shared_preferences_web.dart';
 import 'package:url_launcher_web/url_launcher_web.dart';
 
@@ -15,8 +13,6 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
 // ignore: public_member_api_docs
 void registerPlugins(Registrar registrar) {
-  DeviceInfoPlusPlugin.registerWith(registrar);
-  PackageInfoPlugin.registerWith(registrar);
   SharedPreferencesPlugin.registerWith(registrar);
   UrlLauncherPlugin.registerWith(registrar);
   registrar.registerMessageHandler();

--- a/lib/src/alert_style_widget.dart
+++ b/lib/src/alert_style_widget.dart
@@ -57,7 +57,7 @@ class AlertStyleWidget extends StatelessWidget {
             titlePadding ?? const EdgeInsets.fromLTRB(24.0, 24.0, 24.0, 0.0),
         child: DefaultTextStyle(
           style: Theme.of(context).textTheme.headline6!,
-          child: Semantics(child: title, namesRoute: true),
+          child: Semantics(namesRoute: true, child: title),
         ),
       ));
     } else {

--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -252,10 +252,10 @@ class AppcastItem {
   bool hostSupportsItem({String? osVersion, String? currentPlatform}) {
     var supported = true;
     if (osString != null && osString!.isNotEmpty) {
-      final platformEnum = 'TargetPlatform.' + osString!;
+      final platformEnum = 'TargetPlatform.${osString!}';
       currentPlatform = currentPlatform == null
           ? defaultTargetPlatform.toString()
-          : 'TargetPlatform.' + currentPlatform;
+          : 'TargetPlatform.$currentPlatform';
       supported = platformEnum.toLowerCase() == currentPlatform.toLowerCase();
     }
 

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -50,7 +50,7 @@ class AppcastConfiguration {
 }
 
 /// Creates a shared instance of [Upgrader].
-late Upgrader _sharedInstance = Upgrader();
+Upgrader _sharedInstance = Upgrader();
 
 /// A class to configure the upgrade dialog.
 class Upgrader {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,49 +1,49 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 4.11.0
+version: 5.0.0-alpha.1
 homepage: https://github.com/larryaasen/upgrader
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
-  flutter: ">=2.5.0"
+  sdk: '>=2.17.1 <3.0.0'
+  flutter: ">=3.0.1"
 
 dependencies:
   flutter:
     sdk: flutter
 
   # From fluttercommunity.dev: Get current device information from within the Flutter application.
-  device_info_plus: ">=3.2.0 <7.0.0"
+  device_info_plus: ^8.0.0
 
   # Pure Dart library for HTML5 parsing
-  html: ">=0.15.0 <=0.15.1"
+  html: ^0.15.1
 
   # From Dart Team: A composable, Future-based library for making HTTP requests.
-  http: ">=0.13.0 <=0.13.5"
+  http: ^0.13.5
 
   # From dart.dev: Platform independent access to information about the current operating system.
-  os_detect: ">=2.0.0 <2.1.0"
+  os_detect: ^2.0.1
 
   # From Flutter Community: Provides an API for querying information about an application package.
-  package_info_plus: ">=1.3.0 <3.0.0"
+  package_info_plus: ^3.0.1
 
   # From Flutter Team: Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android).
-  shared_preferences: ">=2.0.3 <2.1.0"
+  shared_preferences: ^2.0.15
 
   # From Flutter Team: A Flutter plugin for launching a URL in the mobile platform.
-  url_launcher: ">=6.1.0 <= 6.1.5"
+  url_launcher: ^6.1.6
 
   # A dart library for comparing and incrementing version numbers with Semantic Versioning.
-  version: ">=2.0.0 <3.1.0"
+  version: ^3.0.2
 
   # A dart library for parsing, traversing, querying, transforming and building XML documents.
-  xml: ">=5.0.2 <7.0.0"
+  xml: ^6.1.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
   # From Dart Team: Mock library for Dart inspired by Mockito.
-  mockito: ">=5.0.0 <5.4.0"
-  flutter_lints: ^1.0.4
+  mockito: ^5.3.2
+  flutter_lints: ^2.0.1
 
 flutter:

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -660,7 +660,7 @@ void main() {
 
       final upgrader2 =
           Upgrader(durationUntilAlertAgain: const Duration(days: 10));
-      final _ = UpgradeCard(upgrader: upgrader2);
+      UpgradeCard(upgrader: upgrader2);
       expect(upgrader2.durationUntilAlertAgain, const Duration(days: 10));
     }, skip: false);
 


### PR DESCRIPTION
I just created a prerelease version 5.0.0-alpha.1 with all packages updated to the latest version, and requiring Flutter version 3.0.1 or above. Check it out and let me know if it works for you. https://pub.dev/packages/upgrader/versions/5.0.0-alpha.1