### PR TITLE
Make sure initialization errors is not ignored

### DIFF
--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -20,7 +20,10 @@ class UpgradeBase extends StatefulWidget {
 }
 
 class UpgradeBaseState extends State<UpgradeBase> {
-  Future<bool> get initialized => widget.upgrader.initialize();
+  Future<bool> get initialized => widget.upgrader.initialize().onError((e, s) {
+        debugPrintStack(label: "Failed to initialize: $e", stackTrace: s);
+        return true;
+      });
 
   @override
   Widget build(BuildContext context) => widget.build(context, this);


### PR DESCRIPTION
On Android willDisplayUpgrade is not called at all when there's no network, e.g. when launching the app in flight mode. So the app is stuck if it depends on this callback to continue. For some reason this doesn't happen on iOS. Adding an error handler to the initialize method makes the behaviour consistent between Android and iOS, and it could potentially catch other errors on both platforms.