### PR TITLE
Add a parameter for the cupertino button text style

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ The Upgrader class can be customized by setting parameters in the constructor.
 * appcastConfig: the appcast configuration, defaults to ```null```
 * canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by UpgradeCard)
 * countryCode: the country code that will override the system locale, which defaults to ```null```
+* cupertinoButtonTextStyle: the text style for the cupertino dialog buttons, which defaults to ```null```
 * languageCode: the language code that will override the system locale, which defaults to ```null```
 * client: an HTTP Client that can be replaced for mock testing, defaults to ```null```
 * debugDisplayAlways: always force the upgrade to be available, defaults to ```false```

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -124,6 +124,10 @@ class Upgrader {
   /// Hide or show release notes (default: true)
   bool showReleaseNotes;
 
+  /// The text style for the cupertino dialog buttons. Used only for
+  /// [UpgradeDialogStyle.cupertino]. Optional.
+  TextStyle? cupertinoButtonTextStyle;
+
   /// Called when [Upgrader] determines that an upgrade may or may not be
   /// displayed. The [value] parameter will be true when it should be displayed,
   /// and false when it should not be displayed. One good use for this callback
@@ -173,6 +177,7 @@ class Upgrader {
     this.languageCode,
     this.minAppVersion,
     this.dialogStyle = UpgradeDialogStyle.material,
+    this.cupertinoButtonTextStyle,
     TargetPlatform? platform,
   })  : client = client ?? http.Client(),
         messages = messages ?? UpgraderMessages(),
@@ -686,13 +691,16 @@ class Upgrader {
       actions: <Widget>[
         if (showIgnore)
           CupertinoDialogAction(
+              textStyle: cupertinoButtonTextStyle,
               child: Text(messages.message(UpgraderMessage.buttonTitleIgnore)!),
               onPressed: () => onUserIgnored(context, true)),
         if (showLater)
           CupertinoDialogAction(
+              textStyle: cupertinoButtonTextStyle,
               child: Text(messages.message(UpgraderMessage.buttonTitleLater)!),
               onPressed: () => onUserLater(context, true)),
         CupertinoDialogAction(
+            textStyle: cupertinoButtonTextStyle,
             isDefaultAction: true,
             child: Text(messages.message(UpgraderMessage.buttonTitleUpdate)!),
             onPressed: () => onUserUpdated(context, !blocked())),

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -164,8 +164,17 @@ void main() {
 
   testWidgets('test UpgradeWidget Cupertino', (WidgetTester tester) async {
     final client = MockITunesSearchClient.setupMockClient();
+
+    const cupertinoButtonTextStyle = TextStyle(
+      fontSize: 14,
+      color: Colors.green,
+    );
     final upgrader = Upgrader(
-        platform: TargetPlatform.iOS, client: client, debugLogging: true);
+      platform: TargetPlatform.iOS,
+      client: client,
+      debugLogging: true,
+      cupertinoButtonTextStyle: cupertinoButtonTextStyle,
+    );
 
     upgrader.installPackageInfo(
         packageInfo: PackageInfo(
@@ -223,6 +232,12 @@ void main() {
     expect(find.text(upgrader.releaseNotes!), findsOneWidget);
     expect(find.text(upgrader.messages.prompt), findsOneWidget);
     expect(find.byType(CupertinoDialogAction), findsNWidgets(3));
+    expect(
+      find.byWidgetPredicate((widget) =>
+          widget is CupertinoDialogAction &&
+          widget.textStyle == cupertinoButtonTextStyle),
+      findsNWidgets(3),
+    );
     expect(find.text(upgrader.messages.buttonTitleIgnore), findsOneWidget);
     expect(find.text(upgrader.messages.buttonTitleLater), findsOneWidget);
     expect(find.text(upgrader.messages.buttonTitleUpdate), findsOneWidget);


### PR DESCRIPTION
Because the text color of a `CupertinoDialogAction` can't be change by the theme in the stable flutter version, I've added a parameter to set the color separately.