### PR TITLE
Added an optional bundleId property to the Upgrader class. if present…

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -70,6 +70,9 @@ class Upgrader {
   /// The country code that will override the system locale. Optional.
   final String? countryCode;
 
+  // An optional override for the Bundle ID to look for in the iTunes store.
+  final String? bundleId;
+
   /// The country code that will override the system locale. Optional. Used only for Android.
   final String? languageCode;
 
@@ -170,6 +173,7 @@ class Upgrader {
     this.showReleaseNotes = true,
     this.canDismissDialog = false,
     this.countryCode,
+    this.bundleId,
     this.languageCode,
     this.minAppVersion,
     this.dialogStyle = UpgradeDialogStyle.material,
@@ -295,8 +299,9 @@ class Upgrader {
       } else if (platform == TargetPlatform.iOS) {
         final iTunes = ITunesSearchAPI();
         iTunes.client = client;
-        final response = await (iTunes
-            .lookupByBundleId(_packageInfo!.packageName, country: country));
+        final response = await (iTunes.lookupByBundleId(
+            bundleId ?? _packageInfo!.packageName,
+            country: country));
 
         if (response != null) {
           _appStoreVersion ??= ITunesResults.version(response);


### PR DESCRIPTION
Added an optional bundleId property to the Upgrader class. if present, this will override which Bundle ID is used to query the iTunes stores.

This addresses issue #250