### PR TITLE
Fix japanese translation

### DIFF
--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -829,7 +829,7 @@ class UpgraderMessages {
         message = 'Aggiornare l\'applicazione?';
         break;
       case 'ja':
-        message = 'アプリのアップデート?';
+        message = 'アプリのアップデート';
         break;
       case 'kk':
         message = 'Жаңарту керек пе?';


### PR DESCRIPTION
? was unnatural in the Japanese sense, so it was removed.

It looks like it was added unintentionally in the commit below.
https://github.com/larryaasen/upgrader/commit/52938cb4e3473c1898b278fc0be028ee18599606