### PR TITLE
Adds platform checks and critical version checks

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -113,7 +113,7 @@ class Appcast {
   }
 
   bool _isCorrectPlatform(XmlAttribute attribute) {
-    final String platformValue = attribute.value; // ios or android
+    final String platformValue = attribute.value;
     final String currentPlatform = Platform.operatingSystem;
 
     return platformValue == currentPlatform;

--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -5,6 +5,7 @@
  */
 
 import 'dart:convert' show utf8;
+import 'dart:io';
 
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
@@ -111,6 +112,13 @@ class Appcast {
     return parseItemsFromXMLString(contents);
   }
 
+  bool _isCorrectPlatform(XmlAttribute attribute) {
+    final String platformValue = attribute.value; // ios or android
+    final String currentPlatform = Platform.operatingSystem;
+
+    return platformValue == currentPlatform;
+  }
+
   List<AppcastItem>? parseItemsFromXMLString(String xmlString) {
     items = null;
 
@@ -150,18 +158,32 @@ class Appcast {
             } else if (name == AppcastConstants.ElementDescription) {
               itemDescription = childNode.text;
             } else if (name == AppcastConstants.ElementEnclosure) {
-              childNode.attributes.forEach((XmlAttribute attribute) {
-                if (attribute.name.toString() ==
-                    AppcastConstants.AttributeVersion) {
-                  enclosureVersion = attribute.value;
-                } else if (attribute.name.toString() ==
-                    AppcastConstants.AttributeOsType) {
-                  osString = attribute.value;
-                } else if (attribute.name.toString() ==
-                    AppcastConstants.AttributeURL) {
-                  fileURL = attribute.value;
-                }
-              });
+              late bool correctPlatform;
+              try {
+                final XmlAttribute platform = childNode.attributes.firstWhere(
+                  (attribute) =>
+                      attribute.name.toString() ==
+                      AppcastConstants.AttributeOsType,
+                );
+                correctPlatform = _isCorrectPlatform(platform);
+              } catch (_) {
+                correctPlatform = true;
+              }
+
+              if (correctPlatform) {
+                childNode.attributes.forEach((XmlAttribute attribute) {
+                  if (attribute.name.toString() ==
+                      AppcastConstants.AttributeVersion) {
+                    enclosureVersion = attribute.value;
+                  } else if (attribute.name.toString() ==
+                      AppcastConstants.AttributeOsType) {
+                    osString = attribute.value;
+                  } else if (attribute.name.toString() ==
+                      AppcastConstants.AttributeURL) {
+                    fileURL = attribute.value;
+                  }
+                });
+              }
             } else if (name == AppcastConstants.ElementMaximumSystemVersion) {
               maximumSystemVersion = childNode.text;
             } else if (name == AppcastConstants.ElementMinimumSystemVersion) {

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -244,7 +244,7 @@ class UpgraderMessages {
       case 'en':
       default:
         message =
-            'A new version of {{appName}} is currently available! Version {{currentAppStoreVersion}} is now available, but you currently have {{currentInstalledVersion}}.';
+            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available-you have {{currentInstalledVersion}}.';
         break;
     }
     return message;

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -244,7 +244,7 @@ class UpgraderMessages {
       case 'en':
       default:
         message =
-            'A new version of {{appName}} is available! Version {{currentAppStoreVersion}} is now available-you have {{currentInstalledVersion}}.';
+            'A new version of {{appName}} is currently available! Version {{currentAppStoreVersion}} is now available, but you currently have {{currentInstalledVersion}}.';
         break;
     }
     return message;

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -301,7 +301,7 @@ class Upgrader {
             _criticalVersion = criticalVersionString;
           }
         } catch (e) {
-          print('Upgrader: updateVersionInfo could not parse version info $e');
+          print('upgrader: updateVersionInfo could not parse version info $e');
           _isCriticalUpdate = false;
         }
 

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -72,12 +72,12 @@ void main() {
       await upgrader.initialize();
 
       expect(upgrader.appName(), 'Upgrader');
-      expect(upgrader.currentAppStoreVersion(), '5.6');
+      expect(upgrader.currentAppStoreOrLastCriticalVersion(), '5.6');
       expect(upgrader.currentInstalledVersion(), '1.9.9');
       expect(upgrader.isUpdateAvailable(), true);
 
       upgrader.installAppStoreVersion('1.2.3');
-      expect(upgrader.currentAppStoreVersion(), '1.2.3');
+      expect(upgrader.currentAppStoreOrLastCriticalVersion(), '1.2.3');
     });
   }, skip: false);
 


### PR DESCRIPTION
This PR solves two different issues that we encountered during the integration of this plugin.

1. If a single Appcast item contains 2 enclosures for each platform, plugin would always choose the latter even if it's the wrong platform. 

Example Appcast: 
```
 <item>
            <title>Version 1.3.0</title>
            <sparkle:version>1.3.0</sparkle:version>
            <enclosure url="https://play.google.com/store/apps/details?id=..."
                       sparkle:os="android"/>
            <enclosure
                    url="https://apps.apple.com/us/app/....."
                    sparkle:os="ios"/>
        </item>
```

So even if the application is running on android it currently chooses the appstore link. 


2. With the introduction of PR https://github.com/larryaasen/upgrader/pull/275 now critical versions will be prioritized even if there is a higher non-prioritized version.

This raises one minor issue:

If the current app version is 1.0.0, and the appcast contains 1.2.0 as a critical update and 1.2.1 as a non-critical update

The pop-up appears as 1.2.1 is a required update and the user must update, even though the reason that the pop up can't be skipped is the 1.2.0 which is the required version. 

This fixes by displaying the critical version (1.2.0) in the dialog instead of the latest (1.2.1) 