### PR TITLE
Updated dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 7.0.1
+version: 7.0.2
 homepage: https://github.com/larryaasen/upgrader
 
 environment:
@@ -12,19 +12,19 @@ dependencies:
     sdk: flutter
 
   # From fluttercommunity.dev: Get current device information from within the Flutter application.
-  device_info_plus: ^9.0.1
+  device_info_plus: ^9.0.2
 
   # Pure Dart library for HTML5 parsing
   html: ^0.15.3
 
   # From Dart Team: A composable, Future-based library for making HTTP requests.
-  http: ^0.13.6
+  http: ^1.0.0
 
   # From dart.dev: Platform independent access to information about the current operating system.
   os_detect: ^2.0.1
 
   # From Flutter Community: Provides an API for querying information about an application package.
-  package_info_plus: ^4.0.1
+  package_info_plus: ^4.0.2
 
   # From Flutter Team: Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android).
   shared_preferences: ^2.1.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   html: ^0.15.3
 
   # From Dart Team: A composable, Future-based library for making HTTP requests.
-  http: ^1.0.0
+  http: '>=0.13.6 <2.0.0'
 
   # From dart.dev: Platform independent access to information about the current operating system.
   os_detect: ^2.0.1


### PR DESCRIPTION
Update the dependencies, especially http -> 1.0.0

<details>
<summary>Test result</summary><p>
## flutter test

``` 
00:01 +1: E:/repos/GitHub/upgrader/test/appcast_test.dart: testing Appcast
upgrader: parseItemsFromXMLString exception: XmlParserException: Expected a single root element at 1:15
upgrader: parseItemsFromXMLString exception: XmlTagException: Unexpected </channel> at 1:1
00:01 +6: E:/repos/GitHub/upgrader/test/appcast_test.dart: testing Appcast host
upgrader: hostSupportsItem invalid osVersion: FormatException: Not a properly formatted version string
00:01 +11: E:/repos/GitHub/upgrader/test/itunes_test.dart: testing minAppVersion
upgrader.ITunesResults.description: NoSuchMethodError: The method '[]' was called on null.
Receiver: null
Tried calling: [](0)
00:02 +15: E:/repos/GitHub/upgrader/test/play_store_test.dart: testing lookupById
upgrader: Can't find an app in the Play Store with the id: com.not.a.valid.application
upgrader: Can't find an app in the Play Store with the id: com.testing.test4
00:02 +20: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test Upgrader class
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540773332535
upgrader: response statusCode: 200
upgrader: initialize called
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 1.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
00:02 +22: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget
upgrader: instantiated.
00:02 +22: E:/repos/GitHub/upgrader/test/play_store_test.dart: testing lookupById with redesignedVersion
upgrader: Can't find an app in the Play Store with the id: com.not.a.valid.application
00:02 +27: E:/repos/GitHub/upgrader/test/play_store_test.dart: testing PlayStoreResults
upgrader: PlayStoreResults.redesignedReleaseNotes exception: Bad state: No element
upgrader: PlayStoreResults.redesignedVersion exception: Bad state: No element
00:02 +28: E:/repos/GitHub/upgrader/test/play_store_test.dart: testing minAppVersion
upgrader: PlayStoreResults.redesignedDescription exception: Bad state: No element
00:02 +29: E:/repos/GitHub/upgrader/test/play_store_test.dart: testing minAppVersion mav tag
upgrader: PlayStoreResults.minAppVersion: mav=a.b.c, tag=\[\:mav\:[\s]*(?<version>[^\s]+)[\s]*\], error=FormatException: Not a properly formatted version string
00:03 +33: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540773361617
upgrader: response statusCode: 200
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: build UpgradeAlert
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
upgrader: shouldDisplayReleaseNotes: true
upgrader: showDialog title: Update App?
upgrader: showDialog message: A new version of Upgrader is available! Version 5.6 is now available-you have 0.9.9.
upgrader: showDialog releaseNotes: Bug fixes.
upgrader: isTooSoon: true
upgrader: button tapped: update now
upgrader: empty _appStoreListingURL
00:03 +34: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget Cupertino
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540773826661
upgrader: response statusCode: 200
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: build UpgradeAlert
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
upgrader: shouldDisplayReleaseNotes: true
upgrader: showDialog title: Update App?
upgrader: showDialog message: A new version of Upgrader is available! Version 5.6 is now available-you have 0.9.9.
upgrader: showDialog releaseNotes: Bug fixes.
upgrader: isTooSoon: true
upgrader: button tapped: update now
upgrader: empty _appStoreListingURL
00:03 +38: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget Card upgrade
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774031886
upgrader: response statusCode: 200
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
UpgradeCard: will display
UpgradeCard: showDialog title: Update App?
UpgradeCard: showDialog message: A new version of Upgrader is available! Version 5.6 is now available-you have 0.9.9.
UpgradeCard: shouldDisplayReleaseNotes: true
UpgradeCard: showDialog releaseNotes: Bug fixes.
upgrader: button tapped: update now
upgrader: empty _appStoreListingURL
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: true
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: isTooSoon: true
upgrader: shouldDisplayUpgrade: false
UpgradeCard: will not display
00:03 +39: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget Card ignore
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774084514
upgrader: response statusCode: 200
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
UpgradeCard: will display
UpgradeCard: showDialog title: Update App?
UpgradeCard: showDialog message: A new version of Upgrader is available! Version 5.6 is now available-you have 0.9.9.
UpgradeCard: shouldDisplayReleaseNotes: true
UpgradeCard: showDialog releaseNotes: Bug fixes.
upgrader: button tapped: ignore
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: true
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: isTooSoon: true
upgrader: shouldDisplayUpgrade: false
UpgradeCard: will not display
00:03 +40: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget Card later
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774147178
upgrader: response statusCode: 200
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
UpgradeCard: will display
UpgradeCard: showDialog title: Update App?
UpgradeCard: showDialog message: A new version of Upgrader is available! Version 5.6 is now available-you have 0.9.9.
UpgradeCard: shouldDisplayReleaseNotes: true
UpgradeCard: showDialog releaseNotes: Bug fixes.
upgrader: button tapped: later
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: true
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: isTooSoon: true
upgrader: shouldDisplayUpgrade: false
UpgradeCard: will not display
00:03 +41: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test upgrader minAppVersion
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774204213
upgrader: response statusCode: 200
FormatException: Not a properly formatted version string
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: true
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 0.9.9
upgrader: minAppVersion: 1.0.0
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
UpgradeCard: will display
UpgradeCard: showDialog title: Update App?
UpgradeCard: showDialog message: A new version of Upgrader is available! Version 5.6 is now available-you have 0.9.9.
UpgradeCard: shouldDisplayReleaseNotes: true
UpgradeCard: showDialog releaseNotes: Bug fixes.
00:03 +42: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test upgrader minAppVersion description android
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.android
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: lookupById url: https://play.google.com/store/apps/details?id=com.testing.test2&gl=US&hl=en&_cb=1685540774246924
upgrader: PlayStoreResults.minAppVersion: 4.5.6
00:03 +43: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test upgrader minAppVersion description ios
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774447843
upgrader: response statusCode: 200
upgrader: ITunesResults.minAppVersion: 4.5.6
00:03 +44: E:/repos/GitHub/upgrader/test/upgrader_test.dart: test UpgradeWidget unknown app
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: IT
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.google.MyApp&country=IT&_cb=1685540774470938
upgrader: response statusCode: 400
UpgradeCard: build UpgradeCard
upgrader: initialize called
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: null
upgrader: installedVersion: 0.1.0
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: false
upgrader: shouldDisplayUpgrade: false
UpgradeCard: will not display
00:03 +45: E:/repos/GitHub/upgrader/test/upgrader_test.dart: initialize should use fake Appcast
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: appcast is available for this platform
upgrader: appcast item count: 0
upgrader: appcast best item version: 1.0.0
upgrader: appcast critical update item version: 1.0.0
00:03 +46: E:/repos/GitHub/upgrader/test/upgrader_test.dart: initialize will use critical version if exists
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: appcast is available for this platform
upgrader: appcast item count: 2
upgrader: appcast best item version: 3.0.0
upgrader: appcast critical update item version: 3.0.0
upgrader: blocked: true
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 3.0.0
upgrader: installedVersion: 1.9.6
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
00:03 +51: E:/repos/GitHub/upgrader/test/upgrader_test.dart: shouldDisplayUpgrade should respect debugDisplayAlways property
upgrader: instantiated.
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: null
upgrader: installedVersion: null
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: false
upgrader: shouldDisplayUpgrade: false
upgrader: blocked: false
upgrader: debugDisplayAlways: true
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: shouldDisplayUpgrade: true
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: null
upgrader: installedVersion: null
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: false
upgrader: shouldDisplayUpgrade: false
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: null
upgrader: installedVersion: null
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: false
upgrader: shouldDisplayUpgrade: false
upgrader: blocked: false
upgrader: debugDisplayAlways: true
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: shouldDisplayUpgrade: true
00:03 +52: E:/repos/GitHub/upgrader/test/upgrader_test.dart: shouldDisplayUpgrade should return true when version is below minAppVersion
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774621219
upgrader: response statusCode: 200
upgrader: blocked: true
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 1.9.6
upgrader: minAppVersion: 2.0.0
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
00:03 +53: E:/repos/GitHub/upgrader/test/upgrader_test.dart: shouldDisplayUpgrade should return true when bestItem has critical update
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: countryCode: US
upgrader: languageCode: en
upgrader: download: https://itunes.apple.com/lookup?bundleId=com.larryaasen.upgrader&country=US&_cb=1685540774630305
upgrader: response statusCode: 200
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: 5.6
upgrader: installedVersion: 2.0.0
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: true
upgrader: shouldDisplayUpgrade: true
00:03 +54: E:/repos/GitHub/upgrader/test/upgrader_test.dart: shouldDisplayUpgrade packageInfo is empty
upgrader: instantiated.
upgrader: initialize called
upgrader: initializing
upgrader: languageCode: en
upgrader: default operatingSystem: windows "Windows 10 Pro" 10.0 (Build 22621)
upgrader: operatingSystem: windows
upgrader: platform: TargetPlatform.iOS
upgrader: defaultTargetPlatform: TargetPlatform.android
upgrader: isAndroid: false, isIOS: false, isLinux: false, isMacOS: false, isWindows: true, isFuchsia: false, isWeb: false
upgrader: blocked: false
upgrader: debugDisplayAlways: false
upgrader: debugDisplayOnce: false
upgrader: hasAlerted: false
upgrader: appStoreVersion: null
upgrader: installedVersion:
upgrader: minAppVersion: null
upgrader: isUpdateAvailable: false
upgrader: shouldDisplayUpgrade: false
00:03 +56: All tests passed!
```
---
</p></details>