### PR TITLE
Check for updates every time the app resumes from the background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.0-alpha.2
+
+- Fixed an issue with checking for updates after resuming from background.
+
 ## 8.0.0-alpha.1
 
 - Added support for checking for updates every time the app resumes from the background. (#272)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
-## Next
+## 8.0.0-alpha.1
 
+- Added support for checking for updates every time the app resumes from the background. (#272)
+- Changed the way Upgrader is initialized to support a stream of evaluation requests. The
+stream is updated each time the app resumes from the background.
 - Added Russian release notes translation. (thanks to @filipp2911)
 
 ## 7.1.0

--- a/example/lib/main-driver.dart
+++ b/example/lib/main-driver.dart
@@ -34,7 +34,7 @@ class _MyAppState extends State<MyApp> {
           ElevatedButton(
             onPressed: () async {
               await Upgrader.clearSavedSettings();
-              _upgrader = Upgrader();
+              _upgrader = Upgrader(debugLogging: true);
               setState(() => _testState = 1);
             },
             child: Text('Dialog Alert'),
@@ -43,7 +43,9 @@ class _MyAppState extends State<MyApp> {
           ElevatedButton(
             onPressed: () async {
               await Upgrader.clearSavedSettings();
-              _upgrader = Upgrader(dialogStyle: UpgradeDialogStyle.cupertino);
+              _upgrader = Upgrader(
+                  dialogStyle: UpgradeDialogStyle.cupertino,
+                  debugLogging: true);
               setState(() => _testState = 2);
             },
             child: Text('Dialog Alert - Cupertino'),
@@ -58,10 +60,12 @@ class _MyAppState extends State<MyApp> {
         content = scaffold;
         break;
       case 1:
-        content = UpgradeAlert(upgrader: _upgrader, child: scaffold);
+        content = UpgradeAlert(
+            key: Key('ua_1'), upgrader: _upgrader, child: scaffold);
         break;
       case 2:
-        content = UpgradeAlert(upgrader: _upgrader, child: scaffold);
+        content = UpgradeAlert(
+            key: Key('ua_2'), upgrader: _upgrader, child: scaffold);
         break;
       default:
     }

--- a/example/test/driver_test/driver_test.dart
+++ b/example/test/driver_test/driver_test.dart
@@ -19,9 +19,15 @@ import 'package:test/test.dart';
 import 'package:path/path.dart' as path_d;
 
 void main() {
-  group('Driver Test:', () {
-    late FlutterDriver driver;
+  late FlutterDriver driver;
 
+  Future<void> verifyText(String text) async {
+    print('verify start: $text');
+    await driver.waitFor(find.text(text));
+    print('verify end');
+  }
+
+  group('Driver Test:', () {
     // Connect to the Flutter driver before running any tests
     setUpAll(() async {
       print('pwd: ${Directory.current.path}');
@@ -43,12 +49,15 @@ void main() {
     });
 
     test('verify app started', () async {
+      print('test started');
       await driver.waitFor(find.text('Upgrader Driver App'));
       await driver.waitFor(find.text('Dialog Alert'));
       await driver.waitFor(find.text('Dialog Alert - Cupertino'));
+      print('test ended');
     });
 
     test('verify alert', () async {
+      print('test started');
       await driver.tap(find.text('Dialog Alert'));
       await driver.waitFor(find.text('Update App?'));
       await driver.waitFor(find.text('Would you like to update it now?'));
@@ -57,17 +66,22 @@ void main() {
       await driver.waitFor(find.text('LATER'));
       await driver.waitFor(find.text('UPDATE NOW'));
       await driver.tap(find.text('IGNORE'));
+      print('test ended');
     });
 
     test('verify alert - cupertino', () async {
+      print('test started');
       await driver.tap(find.text('Dialog Alert - Cupertino'));
-      await driver.waitFor(find.text('Update App?'));
-      await driver.waitFor(find.text('Would you like to update it now?'));
-      await driver.waitFor(find.text('Release Notes'));
-      await driver.waitFor(find.text('IGNORE'));
-      await driver.waitFor(find.text('LATER'));
-      await driver.waitFor(find.text('UPDATE NOW'));
+
+      await verifyText('Update App?');
+      await verifyText('Would you like to update it now?');
+      await verifyText('Release Notes');
+      await verifyText('IGNORE');
+      await verifyText('LATER');
+      await verifyText('UPDATE NOW');
+
       await driver.tap(find.text('IGNORE'));
+      print('test ended');
     });
   });
 }

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Larry Aasen. All rights reserved.
+ * Copyright (c) 2021-2023 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';
@@ -24,19 +24,23 @@ class UpgradeAlert extends UpgradeBase {
       print('upgrader: build UpgradeAlert');
     }
 
-    return FutureBuilder(
-        future: state.initialized,
-        builder: (BuildContext context, AsyncSnapshot<bool> processed) {
-          final checkContext =
-              navigatorKey != null && navigatorKey!.currentContext != null
-                  ? navigatorKey!.currentContext!
-                  : context;
-          if (processed.connectionState == ConnectionState.done &&
-              processed.data != null &&
-              processed.data!) {
-            upgrader.checkVersion(context: checkContext);
+    return StreamBuilder(
+      stream: state.widget.upgrader.evaluationStream,
+      builder:
+          (BuildContext context, AsyncSnapshot<UpgraderEvaluateNeed> snapshot) {
+        final checkContext =
+            navigatorKey != null && navigatorKey!.currentContext != null
+                ? navigatorKey!.currentContext!
+                : context;
+        if (snapshot.connectionState == ConnectionState.active &&
+            snapshot.data != null) {
+          if (upgrader.debugLogging) {
+            print("upgrader: need to evaluate version");
           }
-          return child ?? Container();
-        });
+          upgrader.checkVersion(context: checkContext);
+        }
+        return child ?? const SizedBox.shrink();
+      },
+    );
   }
 }

--- a/lib/src/upgrade_base.dart
+++ b/lib/src/upgrade_base.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2022 Larry Aasen. All rights reserved.
+ * Copyright (c) 2018-2023 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';
@@ -20,12 +20,16 @@ class UpgradeBase extends StatefulWidget {
 }
 
 class UpgradeBaseState extends State<UpgradeBase> {
-  Future<bool> get initialized => widget.upgrader.initialize();
+  @override
+  void initState() {
+    super.initState();
+    initialize();
+  }
 
   @override
   Widget build(BuildContext context) => widget.build(context, this);
 
-  void forceUpdateState() {
-    setState(() {});
-  }
+  Future<bool> initialize() => widget.upgrader.initialize();
+
+  void forceUpdateState() => setState(() {});
 }

--- a/lib/src/upgrade_card.dart
+++ b/lib/src/upgrade_card.dart
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021-2022 Larry Aasen. All rights reserved.
+ * Copyright (c) 2021-2023 Larry Aasen. All rights reserved.
  */
 
 import 'package:flutter/material.dart';
@@ -22,118 +22,119 @@ class UpgradeCard extends UpgradeBase {
   @override
   Widget build(BuildContext context, UpgradeBaseState state) {
     if (upgrader.debugLogging) {
-      print('UpgradeCard: build UpgradeCard');
+      print('upgrader: build UpgradeCard');
     }
 
-    return FutureBuilder(
-        future: state.initialized,
-        builder: (BuildContext context, AsyncSnapshot<bool> processed) {
-          if (processed.connectionState == ConnectionState.done &&
-              processed.data != null &&
-              processed.data!) {
+    return StreamBuilder(
+        stream: state.widget.upgrader.evaluationStream,
+        builder: (BuildContext context,
+            AsyncSnapshot<UpgraderEvaluateNeed> snapshot) {
+          if (snapshot.connectionState == ConnectionState.active &&
+              snapshot.data != null) {
             if (upgrader.shouldDisplayUpgrade()) {
-              final title = upgrader.messages.message(UpgraderMessage.title);
-              final message = upgrader.message();
-              final releaseNotes = upgrader.releaseNotes;
-              final shouldDisplayReleaseNotes =
-                  upgrader.shouldDisplayReleaseNotes();
-              if (upgrader.debugLogging) {
-                print('UpgradeCard: will display');
-                print('UpgradeCard: showDialog title: $title');
-                print('UpgradeCard: showDialog message: $message');
-                print(
-                    'UpgradeCard: shouldDisplayReleaseNotes: $shouldDisplayReleaseNotes');
-
-                print('UpgradeCard: showDialog releaseNotes: $releaseNotes');
-              }
-
-              Widget? notes;
-              if (shouldDisplayReleaseNotes && releaseNotes != null) {
-                notes = Padding(
-                    padding: const EdgeInsets.only(top: 15.0),
-                    child: Column(
-                      mainAxisSize: MainAxisSize.min,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                            Upgrader()
-                                    .messages
-                                    .message(UpgraderMessage.releaseNotes) ??
-                                '',
-                            style:
-                                const TextStyle(fontWeight: FontWeight.bold)),
-                        Text(
-                          releaseNotes,
-                          maxLines: 15,
-                          overflow: TextOverflow.ellipsis,
-                        ),
-                      ],
-                    ));
-              }
-
-              return Card(
-                  color: Colors.white,
-                  margin: margin,
-                  child: AlertStyleWidget(
-                      title: Text(title ?? ''),
-                      content: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        mainAxisAlignment: MainAxisAlignment.start,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Text(message),
-                          Padding(
-                              padding: const EdgeInsets.only(top: 15.0),
-                              child: Text(upgrader.messages
-                                      .message(UpgraderMessage.prompt) ??
-                                  '')),
-                          if (notes != null) notes,
-                        ],
-                      ),
-                      actions: <Widget>[
-                        if (upgrader.showIgnore)
-                          TextButton(
-                              child: Text(upgrader.messages.message(
-                                      UpgraderMessage.buttonTitleIgnore) ??
-                                  ''),
-                              onPressed: () {
-                                // Save the date/time as the last time alerted.
-                                upgrader.saveLastAlerted();
-
-                                upgrader.onUserIgnored(context, false);
-                                state.forceUpdateState();
-                              }),
-                        if (upgrader.showLater)
-                          TextButton(
-                              child: Text(upgrader.messages.message(
-                                      UpgraderMessage.buttonTitleLater) ??
-                                  ''),
-                              onPressed: () {
-                                // Save the date/time as the last time alerted.
-                                upgrader.saveLastAlerted();
-
-                                upgrader.onUserLater(context, false);
-                                state.forceUpdateState();
-                              }),
-                        TextButton(
-                            child: Text(upgrader.messages.message(
-                                    UpgraderMessage.buttonTitleUpdate) ??
-                                ''),
-                            onPressed: () {
-                              // Save the date/time as the last time alerted.
-                              upgrader.saveLastAlerted();
-
-                              upgrader.onUserUpdated(context, false);
-                              state.forceUpdateState();
-                            }),
-                      ]));
+              return buildUpgradeCard(context, state);
             } else {
               if (upgrader.debugLogging) {
-                print('UpgradeCard: will not display');
+                print('upgrader: UpgradeCard will not display');
               }
             }
           }
-          return const SizedBox(width: 0.0, height: 0.0);
+          return const SizedBox.shrink();
         });
+  }
+
+  /// Build the UpgradeCard Widget.
+  Widget buildUpgradeCard(BuildContext context, UpgradeBaseState state) {
+    final title = upgrader.messages.message(UpgraderMessage.title);
+    final message = upgrader.message();
+    final releaseNotes = upgrader.releaseNotes;
+    final shouldDisplayReleaseNotes = upgrader.shouldDisplayReleaseNotes();
+    if (upgrader.debugLogging) {
+      print('upgrader: UpgradeCard: will display');
+      print('upgrader: UpgradeCard: showDialog title: $title');
+      print('upgrader: UpgradeCard: showDialog message: $message');
+      print(
+          'upgrader: UpgradeCard: shouldDisplayReleaseNotes: $shouldDisplayReleaseNotes');
+
+      print('upgrader: UpgradeCard: showDialog releaseNotes: $releaseNotes');
+    }
+
+    Widget? notes;
+    if (shouldDisplayReleaseNotes && releaseNotes != null) {
+      notes = Padding(
+          padding: const EdgeInsets.only(top: 15.0),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                  Upgrader().messages.message(UpgraderMessage.releaseNotes) ??
+                      '',
+                  style: const TextStyle(fontWeight: FontWeight.bold)),
+              Text(
+                releaseNotes,
+                maxLines: 15,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ));
+    }
+
+    return Card(
+        color: Colors.white,
+        margin: margin,
+        child: AlertStyleWidget(
+            title: Text(title ?? ''),
+            content: Column(
+              mainAxisSize: MainAxisSize.min,
+              mainAxisAlignment: MainAxisAlignment.start,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Text(message),
+                Padding(
+                    padding: const EdgeInsets.only(top: 15.0),
+                    child: Text(
+                        upgrader.messages.message(UpgraderMessage.prompt) ??
+                            '')),
+                if (notes != null) notes,
+              ],
+            ),
+            actions: <Widget>[
+              if (upgrader.showIgnore)
+                TextButton(
+                    child: Text(upgrader.messages
+                            .message(UpgraderMessage.buttonTitleIgnore) ??
+                        ''),
+                    onPressed: () {
+                      // Save the date/time as the last time alerted.
+                      upgrader.saveLastAlerted();
+
+                      upgrader.onUserIgnored(context, false);
+                      state.forceUpdateState();
+                    }),
+              if (upgrader.showLater)
+                TextButton(
+                    child: Text(upgrader.messages
+                            .message(UpgraderMessage.buttonTitleLater) ??
+                        ''),
+                    onPressed: () {
+                      // Save the date/time as the last time alerted.
+                      upgrader.saveLastAlerted();
+
+                      upgrader.onUserLater(context, false);
+                      state.forceUpdateState();
+                    }),
+              TextButton(
+                  child: Text(upgrader.messages
+                          .message(UpgraderMessage.buttonTitleUpdate) ??
+                      ''),
+                  onPressed: () {
+                    // Save the date/time as the last time alerted.
+                    upgrader.saveLastAlerted();
+
+                    upgrader.onUserUpdated(context, false);
+                    state.forceUpdateState();
+                  }),
+            ]));
   }
 }

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -283,7 +283,7 @@ class Upgrader with WidgetsBindingObserver {
 
   /// Handle application events.
   @override
-  void didChangeAppLifecycleState(AppLifecycleState state) async {
+  Future<void> didChangeAppLifecycleState(AppLifecycleState state) async {
     super.didChangeAppLifecycleState(state);
 
     // When app has resumed from background.
@@ -334,8 +334,8 @@ class Upgrader with WidgetsBindingObserver {
           _isCriticalUpdate = false;
         }
 
-        _appStoreVersion ??= bestItem.versionString;
-        _appStoreListingURL ??= bestItem.fileURL;
+        _appStoreVersion = bestItem.versionString;
+        _appStoreListingURL = bestItem.fileURL;
         _releaseNotes = bestItem.itemDescription;
       }
     } else {
@@ -367,8 +367,8 @@ class Upgrader with WidgetsBindingObserver {
             .lookupByBundleId(_packageInfo!.packageName, country: country));
 
         if (response != null) {
-          _appStoreVersion ??= ITunesResults.version(response);
-          _appStoreListingURL ??= ITunesResults.trackViewUrl(response);
+          _appStoreVersion = ITunesResults.version(response);
+          _appStoreListingURL = ITunesResults.trackViewUrl(response);
           _releaseNotes ??= ITunesResults.releaseNotes(response);
           final mav = ITunesResults.minAppVersion(response);
           if (mav != null) {
@@ -573,16 +573,14 @@ class Upgrader with WidgetsBindingObserver {
       return false;
     }
 
-    if (_updateAvailable == null) {
-      try {
-        final appStoreVersion = Version.parse(_appStoreVersion!);
-        final installedVersion = Version.parse(_installedVersion!);
+    try {
+      final appStoreVersion = Version.parse(_appStoreVersion!);
+      final installedVersion = Version.parse(_installedVersion!);
 
-        final available = appStoreVersion > installedVersion;
-        _updateAvailable = available ? _appStoreVersion : null;
-      } on Exception catch (e) {
-        print('upgrader: isUpdateAvailable: $e');
-      }
+      final available = appStoreVersion > installedVersion;
+      _updateAvailable = available ? _appStoreVersion : null;
+    } on Exception catch (e) {
+      print('upgrader: isUpdateAvailable: $e');
     }
     final isAvailable = _updateAvailable != null;
     if (debugLogging) print('upgrader: isUpdateAvailable: $isAvailable');

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -33,6 +33,9 @@ typedef WillDisplayUpgradeCallback = void Function(
     String? installedVersion,
     String? appStoreVersion});
 
+/// The type of data in the stream.
+typedef UpgraderEvaluateNeed = bool;
+
 /// There are two different dialog styles: Cupertino and Material
 enum UpgradeDialogStyle { cupertino, material }
 
@@ -53,7 +56,7 @@ class AppcastConfiguration {
 Upgrader _sharedInstance = Upgrader();
 
 /// A class to configure the upgrade dialog.
-class Upgrader {
+class Upgrader with WidgetsBindingObserver {
   /// Provide an Appcast that can be replaced for mock testing.
   final Appcast? appcast;
 
@@ -151,6 +154,11 @@ class Upgrader {
 
   /// Track the initialization future so that [initialize] can be called multiple times.
   Future<bool>? _futureInit;
+
+  /// A stream that provides a series of values each time an evaluation should be performed.
+  /// The values will always be null or true.
+  final _streamController = StreamController<UpgraderEvaluateNeed>();
+  Stream<UpgraderEvaluateNeed> get evaluationStream => _streamController.stream;
 
   final notInitializedExceptionMessage =
       'initialize() not called. Must be called first.';
@@ -255,9 +263,37 @@ class Upgrader {
 
       await _updateVersionInfo();
 
+      // Add an observer of application events.
+      WidgetsBinding.instance.addObserver(this);
+
+      /// Trigger the stream to indicate an evaluation should be performed.
+      /// The value will always be true.
+      _streamController.add(true);
+
       return true;
     });
     return _futureInit!;
+  }
+
+  /// Remove any resources allocated.
+  void dispose() {
+    // Remove the observer of application events.
+    WidgetsBinding.instance.removeObserver(this);
+  }
+
+  /// Handle application events.
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) async {
+    super.didChangeAppLifecycleState(state);
+
+    // When app has resumed from background.
+    if (state == AppLifecycleState.resumed) {
+      await _updateVersionInfo();
+
+      /// Trigger the stream to indicate another evaluation should be performed.
+      /// The value will always be true.
+      _streamController.add(true);
+    }
   }
 
   Future<bool> _updateVersionInfo() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 8.0.0-alpha.1
+version: 8.0.0-alpha.2
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 7.1.0
+version: 8.0.0-alpha.1
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/test/device_test.dart
+++ b/test/device_test.dart
@@ -8,7 +8,7 @@ import 'package:upgrader/upgrader.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late Map _useAndroidInfo;
+  late Map useAndroidInfo;
 
   // Makes getApplicationDocumentsDirectory work.
   const MethodChannel channelDeviceInfo =
@@ -16,19 +16,19 @@ void main() {
   // ignore: deprecated_member_use
   channelDeviceInfo.setMockMethodCallHandler((MethodCall methodCall) async {
     if (methodCall.method == 'getDeviceInfo') {
-      return _useAndroidInfo;
+      return useAndroidInfo;
     }
     return 'unknown';
   });
 
   test('testing UpgraderDevice', () async {
-    _useAndroidInfo = _androidInfo(baseOS: '1.2.3');
+    useAndroidInfo = _androidInfo(baseOS: '1.2.3');
     final device = UpgraderDevice();
     expect(await device.getOsVersionString(MockUpgraderOS(android: true)),
         '1.2.3');
 
     // Verify invalid OS version
-    _useAndroidInfo = _androidInfo(baseOS: '.');
+    useAndroidInfo = _androidInfo(baseOS: '.');
     expect(
         await device.getOsVersionString(MockUpgraderOS(android: true)), isNull);
   });

--- a/test/device_test.dart
+++ b/test/device_test.dart
@@ -8,7 +8,7 @@ import 'package:upgrader/upgrader.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  late Map useAndroidInfo;
+  late Map deviceInfo;
 
   // Makes getApplicationDocumentsDirectory work.
   const MethodChannel channelDeviceInfo =
@@ -16,21 +16,33 @@ void main() {
   // ignore: deprecated_member_use
   channelDeviceInfo.setMockMethodCallHandler((MethodCall methodCall) async {
     if (methodCall.method == 'getDeviceInfo') {
-      return useAndroidInfo;
+      return deviceInfo;
     }
     return 'unknown';
   });
 
-  test('testing UpgraderDevice', () async {
-    useAndroidInfo = _androidInfo(baseOS: '1.2.3');
+  test('testing UpgraderDevice Android', () async {
+    deviceInfo = _androidInfo(baseOS: '1.2.3');
     final device = UpgraderDevice();
     expect(await device.getOsVersionString(MockUpgraderOS(android: true)),
         '1.2.3');
 
     // Verify invalid OS version
-    useAndroidInfo = _androidInfo(baseOS: '.');
+    deviceInfo = _androidInfo(baseOS: '.');
     expect(
         await device.getOsVersionString(MockUpgraderOS(android: true)), isNull);
+  });
+
+  test('testing UpgraderDevice macOS', () async {
+    deviceInfo = _macOSInfo(baseOS: '1.2.3');
+    final device = UpgraderDevice();
+    expect(
+        await device.getOsVersionString(MockUpgraderOS(macos: true)), '1.2.3');
+
+    // Verify invalid OS version
+    deviceInfo = _macOSInfo(baseOS: '.');
+    expect(
+        await device.getOsVersionString(MockUpgraderOS(macos: true)), isNull);
   });
 }
 
@@ -76,4 +88,25 @@ Map _androidInfo({required String baseOS}) {
     'version': version,
   };
   return build;
+}
+
+Map _macOSInfo({required String baseOS}) {
+  final info = {
+    'computerName': 'a',
+    'hostName': 'a',
+    'arch': 'a',
+    'model': 'a',
+    'kernelVersion': 'a',
+    'osRelease':
+        'Version $baseOS (Build 22D68)', // This is the only value used in the test.
+    'majorVersion': 0,
+    'minorVersion': 0,
+    'patchVersion': 0,
+    'activeCPUs': 0,
+    'memorySize': 0,
+    'cpuFrequency': 0,
+    'systemGUID': 'a',
+  };
+
+  return info;
 }

--- a/test/device_test.dart
+++ b/test/device_test.dart
@@ -1,0 +1,79 @@
+// Copyright (c) 2023 Larry Aasen. All rights reserved.
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:upgrader/src/upgrader_device.dart';
+import 'package:upgrader/upgrader.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Map _useAndroidInfo;
+
+  // Makes getApplicationDocumentsDirectory work.
+  const MethodChannel channelDeviceInfo =
+      MethodChannel('dev.fluttercommunity.plus/device_info');
+  // ignore: deprecated_member_use
+  channelDeviceInfo.setMockMethodCallHandler((MethodCall methodCall) async {
+    if (methodCall.method == 'getDeviceInfo') {
+      return _useAndroidInfo;
+    }
+    return 'unknown';
+  });
+
+  test('testing UpgraderDevice', () async {
+    _useAndroidInfo = _androidInfo(baseOS: '1.2.3');
+    final device = UpgraderDevice();
+    expect(await device.getOsVersionString(MockUpgraderOS(android: true)),
+        '1.2.3');
+
+    // Verify invalid OS version
+    _useAndroidInfo = _androidInfo(baseOS: '.');
+    expect(
+        await device.getOsVersionString(MockUpgraderOS(android: true)), isNull);
+  });
+}
+
+Map _androidInfo({required String baseOS}) {
+  final displayMetrics = {
+    'widthPx': 0.0,
+    'heightPx': 0.0,
+    'xDpi': 0.0,
+    'yDpi': 0.0,
+  };
+  final version = {
+    'baseOS': baseOS, // This is the only value used in the test.
+    'codename': 'a',
+    'incremental': 'a',
+    'previewSdkInt': 1,
+    'release': 'a',
+    'sdkInt': 1,
+    'securityPatch': 'a',
+  };
+
+  final build = <String, dynamic>{
+    'board': 'a',
+    'bootloader': 'a',
+    'brand': 'a',
+    'device': 'a',
+    'display': 'a',
+    'fingerprint': 'a',
+    'hardware': 'a',
+    'host': 'a',
+    'id': 'a',
+    'manufacturer': 'a',
+    'model': 'a',
+    'product': 'a',
+    'supported32BitAbis': ['a'],
+    'supported64BitAbis': ['a'],
+    'supportedAbis': ['a'],
+    'tags': 'a',
+    'type': 'a',
+    'isPhysicalDevice': false,
+    'systemFeatures': [],
+    'displayMetrics': displayMetrics,
+    'serialNumber': 'a',
+    'version': version,
+  };
+  return build;
+}

--- a/test/mock_itunes_client.dart
+++ b/test/mock_itunes_client.dart
@@ -53,6 +53,38 @@ class MockITunesSearchClient {
           ITunesSearchAPI().lookupURLByBundleId('com.larryaasen.upgrader',
               country: country, useCacheBuster: false)) {
         return http.Response(response, 200);
+      } else if (url ==
+          ITunesSearchAPI().lookupURLByBundleId('com.larryaasen.upgrader.2',
+              country: country, useCacheBuster: false)) {
+        return http.Response(
+            json.encode({
+              'results': [
+                {
+                  'version': '7.0',
+                  'bundleId': 'com.google.Maps',
+                  'currency': currency,
+                  'releaseNotes': 'Bug fixes.',
+                  if (description.isNotEmpty) 'description': description
+                }
+              ]
+            }),
+            200);
+      } else if (url ==
+          ITunesSearchAPI().lookupURLByBundleId('com.larryaasen.upgrader.3',
+              country: country, useCacheBuster: false)) {
+        return http.Response(
+            json.encode({
+              'results': [
+                {
+                  'version': '1.0',
+                  'bundleId': 'com.google.Maps',
+                  'currency': currency,
+                  'releaseNotes': 'Bug fixes.',
+                  if (description.isNotEmpty) 'description': description
+                }
+              ]
+            }),
+            200);
       }
       if (url ==
           ITunesSearchAPI().lookupURLByBundleId('com.google.MyApp',

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -116,8 +116,44 @@ void main() {
 
       upgrader.installAppStoreVersion('1.2.3');
       expect(upgrader.currentAppStoreVersion(), '1.2.3');
+      expect(upgrader.isUpdateAvailable(), false);
+
+      upgrader.installAppStoreVersion('6.2.3');
+      expect(upgrader.currentAppStoreVersion(), '6.2.3');
+      expect(upgrader.isUpdateAvailable(), true);
+
+      upgrader.installAppStoreVersion('1.1.1');
+      expect(upgrader.currentAppStoreVersion(), '1.1.1');
+      expect(upgrader.isUpdateAvailable(), false);
+
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(upgrader.isUpdateAvailable(), true);
+
+      upgrader.installAppStoreVersion('1.1.1');
+      expect(upgrader.currentAppStoreVersion(), '1.1.1');
+      expect(upgrader.isUpdateAvailable(), false);
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+              appName: 'Upgrader',
+              packageName: 'com.larryaasen.upgrader.2',
+              version: '1.9.9',
+              buildNumber: '400'));
+
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(upgrader.isUpdateAvailable(), true);
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+              appName: 'Upgrader',
+              packageName: 'com.larryaasen.upgrader.3',
+              version: '1.9.9',
+              buildNumber: '400'));
+
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(upgrader.isUpdateAvailable(), false);
     });
-  }, skip: false);
+  });
 
   testWidgets('test installAppStoreListingURL', (WidgetTester tester) async {
     final upgrader = Upgrader();


### PR DESCRIPTION
Added support for checking for updates every time the app resumes from the background. (#272)

Changed the way Upgrader is initialized to support a stream of evaluation requests. The stream is updated each time the app resumes from the background.