### PR TITLE
Adding possibility to align the action buttons.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The Upgrader class can be customized by setting parameters in the constructor.
 
 * appcast: Provide an Appcast that can be replaced for mock testing, defaults to ```null```
 * appcastConfig: the appcast configuration, defaults to ```null```
+* buttonsAlignment: to control the alignment of the action buttons, defaults to ```null```
 * canDismissDialog: can alert dialog be dismissed on tap outside of the alert dialog, which defaults to ```false``` (not used by UpgradeCard)
 * countryCode: the country code that will override the system locale, which defaults to ```null```
 * cupertinoButtonTextStyle: the text style for the cupertino dialog buttons, which defaults to ```null```

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -128,6 +128,9 @@ class Upgrader with WidgetsBindingObserver {
   /// [UpgradeDialogStyle.cupertino]. Optional.
   TextStyle? cupertinoButtonTextStyle;
 
+  /// The alignment for the action buttons. Optional.
+  MainAxisAlignment? buttonsAlignment;
+
   /// Called when [Upgrader] determines that an upgrade may or may not be
   /// displayed. The [value] parameter will be true when it should be displayed,
   /// and false when it should not be displayed. One good use for this callback
@@ -190,6 +193,7 @@ class Upgrader with WidgetsBindingObserver {
     this.minAppVersion,
     this.dialogStyle = UpgradeDialogStyle.material,
     this.cupertinoButtonTextStyle,
+    this.buttonsAlignment,
     UpgraderOS? upgraderOS,
   })  : client = client ?? http.Client(),
         messages = messages ?? UpgraderMessages(),
@@ -721,10 +725,15 @@ class Upgrader with WidgetsBindingObserver {
           context, () => onUserUpdated(context, !blocked())),
     ];
 
-    return cupertino
-        ? CupertinoAlertDialog(
-            title: textTitle, content: content, actions: actions)
-        : AlertDialog(title: textTitle, content: content, actions: actions);
+    if (cupertino) {
+      return CupertinoAlertDialog(title: textTitle, content: content, actions: actions);
+    }
+
+    return AlertDialog(
+      title: textTitle,
+      content: content,
+      actions: actions,
+      actionsAlignment: buttonsAlignment);
   }
 
   Widget _button(bool cupertino, String? text, BuildContext context,


### PR DESCRIPTION
By default the buttons are aligned at the right-hand side of the dialog. You can override this with this change.