### PR TITLE
feature: add support for appcast ABI filtering

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>upgrader</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.core.runtime.prefs
+++ b/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,7 +12,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/lib/src/upgrader_device.dart
+++ b/lib/src/upgrader_device.dart
@@ -48,14 +48,30 @@ class UpgraderDevice {
 
     return osVersionString;
   }
+
+  /// Returns preferred ABI supported by the OS, if any. Currently, Android only.
+  Future<String?> getPreferredAbi(UpgraderOS upgraderOS) async {
+    final deviceInfo = DeviceInfoPlugin();
+    if (upgraderOS.isAndroid) {
+      final androidInfo = await deviceInfo.androidInfo;
+      final abiList = androidInfo.supportedAbis;
+      return abiList.isNotEmpty ? abiList.first : null;
+    } else {
+      return null;
+    }
+  }
 }
 
 class MockUpgraderDevice extends UpgraderDevice {
-  MockUpgraderDevice({this.osVersionString = ''});
+  MockUpgraderDevice({this.osVersionString = '', this.deviceAbi});
 
   final String osVersionString;
+  final String? deviceAbi;
 
   @override
   Future<String?> getOsVersionString(UpgraderOS upgraderOS) async =>
       osVersionString;
+
+  @override
+  Future<String?> getPreferredAbi(UpgraderOS upgraderOS) async => deviceAbi;
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   os_detect: ^2.0.1
 
   # From Flutter Community: Provides an API for querying information about an application package.
-  package_info_plus: ^4.0.1
+  package_info_plus: ^8.0.0
 
   # From Flutter Team: Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android).
   shared_preferences: ^2.1.1
@@ -44,6 +44,6 @@ dev_dependencies:
 
   # From Dart Team: Mock library for Dart inspired by Mockito.
   mockito: ^5.4.0
-  flutter_lints: ^2.0.1
+  flutter_lints: ^3.0.2
 
 flutter:

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -191,6 +191,33 @@ void main() {
     final bestItem = appcast.bestItem();
     expect(bestItem, isNull);
   });
+  test('Appcast ABI', () async {
+    var testFile = await getTestFile(filePath: 'test/testappcast-abi.xml');
+    // no ABI
+    var appcast = TestAppcast(
+        client: setupMockClient(),
+        upgraderOS: MockUpgraderOS(android: true),
+        upgraderDevice: MockUpgraderDevice());
+    await appcast.parseAppcastItemsFromFile(testFile);
+    var bestItem = appcast.bestItem();
+    expect(bestItem, isNotNull); // nothing specified so anything goes
+    // wrong ABI
+    appcast = TestAppcast(
+        client: setupMockClient(),
+        upgraderOS: MockUpgraderOS(android: true),
+        upgraderDevice: MockUpgraderDevice(deviceAbi: 'bogus-abi'));
+    await appcast.parseAppcastItemsFromFile(testFile);
+    bestItem = appcast.bestItem();
+    expect(bestItem, isNull);
+    // right ABI
+    appcast = TestAppcast(
+        client: setupMockClient(),
+        upgraderOS: MockUpgraderOS(android: true),
+        upgraderDevice: MockUpgraderDevice(deviceAbi: 'arm64-v8a'));
+    await appcast.parseAppcastItemsFromFile(testFile);
+    bestItem = appcast.bestItem();
+    expect(bestItem!.abi, 'arm64-v8a');
+  });
 }
 
 void validateItems(List<AppcastItem> items, Appcast appcast) {

--- a/test/device_test.dart
+++ b/test/device_test.dart
@@ -26,11 +26,16 @@ void main() {
     final device = UpgraderDevice();
     expect(await device.getOsVersionString(MockUpgraderOS(android: true)),
         '1.2.3');
+    expect(await device.getPreferredAbi(MockUpgraderOS(android: true)),
+        'arm64-v8a');
 
     // Verify invalid OS version
     deviceInfo = _androidInfo(baseOS: '.');
     expect(
         await device.getOsVersionString(MockUpgraderOS(android: true)), isNull);
+    // only Android supports ABI
+    expect(
+        await device.getPreferredAbi(MockUpgraderOS(android: false)), isNull);
   });
 
   test('testing UpgraderDevice macOS', () async {
@@ -78,7 +83,7 @@ Map _androidInfo({required String baseOS}) {
     'product': 'a',
     'supported32BitAbis': ['a'],
     'supported64BitAbis': ['a'],
-    'supportedAbis': ['a'],
+    'supportedAbis': ['arm64-v8a'], // also used in test
     'tags': 'a',
     'type': 'a',
     'isPhysicalDevice': false,

--- a/test/testappcast-abi.xml
+++ b/test/testappcast-abi.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0"
+  xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <title>Releases</title>
+    <item>
+      <enclosure sparkle:version="2.1.1" sparkle:os="android" abi="armeabi-v7a"/>
+    </item>
+    <item>
+      <enclosure sparkle:version="2.1.1" sparkle:os="android" abi="arm64-v8a"/>
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
This adds ABI filters in <enclosure> elements. Only Android is supported at the time. Original functionality is preserved: if abi is not specified, old behavior is in effect.

**Justification**
Filtering only based on the OS/version is too limiting for Android devices. It is generally recommended to build artifacts per ABI, but there is currently no way to thus filter appcast items, forcing one to use a _"fat"_ apk which is a few times bigger than necessary.

**Implementation**
Although only Android is currently supported for this filtering, other OS can be easily added, if needed. The filter is on the \<enclosure\> level, along with the binary (url). Since "sparkle" domain does not support "abi" (at least as far as I know - I could not find the complete appcast.xml  schema anywhere), it is in the default (no prefix) domain, for simplicity.

**Testing**
Basic unit testing was added. Also, limited testing conducted in production.

Please come back with questions/comments, if any. Hoping to using this in a official release soon!