### PR TITLE
Option to add custom message to show on the body.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -27,10 +27,13 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Upgrader Example',
       home: UpgradeAlert(
+          upgrader: Upgrader(
+              messages: UpgraderMessages(
+                  code: 'custom', customMessage: 'Hello World!')),
           child: Scaffold(
-        appBar: AppBar(title: Text('Upgrader Example')),
-        body: Center(child: Text('Checking...')),
-      )),
+            appBar: AppBar(title: Text('Upgrader Example')),
+            body: Center(child: Text('Checking...')),
+          )),
     );
   }
 }

--- a/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -12,7 +12,7 @@ import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
-  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
+  FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -48,14 +48,19 @@ enum UpgraderMessage {
 ///
 /// UpgradeAlert(messages: MyUpgraderMessages());
 /// ```
-///
+/// A new [custom] case added to [code] to display [customMessage] instead of default text.
+/// Optionally you can pass desired text for [customMessage] param.
+/// Default value is __"There is an update available for the app."__
 class UpgraderMessages {
   /// The primary language subtag for the locale, which defaults to the
   /// system-reported default locale of the device.
   final String languageCode;
+  final String customMessage;
 
   /// Provide a [code] to override the system-reported default locale.
-  UpgraderMessages({String? code})
+  UpgraderMessages(
+      {String? code,
+      this.customMessage = 'There is an update available for the app.'})
       : languageCode = (code ?? findLanguageCode()) {
     assert(languageCode.isNotEmpty);
   }
@@ -108,6 +113,7 @@ class UpgraderMessages {
 
   /// Override this getter to provide a custom value. Values provided in the
   /// [message] function will be used over this value.
+  // todo: get custom message here
   String get body {
     String message;
     switch (languageCode) {
@@ -242,6 +248,9 @@ class UpgraderMessages {
       case 'zh':
         message =
             '{{appName}}有新的版本！您拥有{{currentInstalledVersion}}的版本可更新到{{currentAppStoreVersion}}的版本。';
+        break;
+      case 'custom':
+        message = customMessage;
         break;
       case 'en':
       default:


### PR DESCRIPTION
UpgradeMessage class has been modified to accept custom messages to display instead of default text.
For this, 
- I have added a code = 'custom' case on the same class. Added customMessage parameter in the class which accepts String.
- By default, customMessage shows "There is an update available for the app."

To invoke, pass 'custom' as a value to the code param on UpgradeMessage constructor along with desired text for customMessage param as shown in the example app on the repo/