### PR TITLE
Fix #375 to correctly decode special characters in app titles.

### DIFF
--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -6,6 +6,7 @@ import 'package:html/dom.dart';
 import 'package:html/parser.dart' show parse;
 import 'package:http/http.dart' as http;
 import 'package:version/version.dart';
+import 'dart:convert';  
 
 class PlayStoreSearchAPI {
   PlayStoreSearchAPI({http.Client? client}) : client = client ?? http.Client();
@@ -256,8 +257,8 @@ extension PlayStoreResults on PlayStoreSearchAPI {
           nameElement
               .substring(storeNameStartIndex)
               .indexOf(patternEndOfString);
-      final storeName =
-          nameElement.substring(storeNameStartIndex, storeNameEndIndex);
+      final storeName = jsonDecode(
+          '"${nameElement.substring(storeNameStartIndex, storeNameEndIndex)}"');
 
       final versionElement = additionalInfoElementsFiltered
           .where((element) => element.text.contains("\"$storeName\""))


### PR DESCRIPTION
This is to fix playstore parsing when app name in playstore contains special characters like apostrophe, ampersand or other unicode characters.

I have tested the changes on the following page and it seems to work correctly:
https://play.google.com/store/apps/details?id=com.mcdonalds.app

