### PR TITLE
Adding optional headers parameter to Http client request

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -101,10 +101,10 @@ class Appcast {
   }
 
   /// Download the Appcast from [appCastURL].
-  Future<List<AppcastItem>?> parseAppcastItemsFromUri(String appCastURL) async {
+  Future<List<AppcastItem>?> parseAppcastItemsFromUri(String appCastURL, {Map<String,String>? headers}) async {
     http.Response response;
     try {
-      response = await client.get(Uri.parse(appCastURL));
+      response = await client.get(Uri.parse(appCastURL), headers: headers);
     } catch (e) {
       print('upgrader: parseAppcastItemsFromUri exception: $e');
       return null;

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -40,10 +40,12 @@ typedef UpgraderEvaluateNeed = bool;
 /// names, such as "android", "fuchsia", "ios", "linux" "macos", "web", "windows".
 class AppcastConfiguration {
   final List<String>? supportedOS;
+  final Map<String, String>? headers;
   final String? url;
 
   AppcastConfiguration({
     this.supportedOS,
+    this.headers,
     this.url,
   });
 }
@@ -256,7 +258,8 @@ class Upgrader with WidgetsBindingObserver {
       }
 
       final appcast = this.appcast ?? Appcast(client: client);
-      await appcast.parseAppcastItemsFromUri(appcastConfig!.url!);
+      await appcast.parseAppcastItemsFromUri(appcastConfig!.url!,
+          headers: appcastConfig!.headers);
       if (debugLogging) {
         var count = appcast.items == null ? 0 : appcast.items!.length;
         print('upgrader: appcast item count: $count');

--- a/test/fake_appcast.dart
+++ b/test/fake_appcast.dart
@@ -42,7 +42,7 @@ class FakeAppcast extends Fake implements TestAppcast {
   }
 
   @override
-  Future<List<AppcastItem>> parseAppcastItemsFromUri(String appCastURL) async {
+  Future<List<AppcastItem>> parseAppcastItemsFromUri(String appCastURL, {Map<String,String>? headers}) async {
     callCount++;
 
     return [AppcastItem()];


### PR DESCRIPTION
# Context 🤔
App cast an http request to fetch version update file on a remote server. Issue is, when the file is protected (example: file is on a private remote repository), app cannot access the files without headers.

# What did we do ? 🏮

Added optional header parameters to `AppcastConfiguration` object so that we can easily pass set of headers if we need to.

# What to test ? 🧪

Test that the added parameter is really optional and doesn't break the basic flow.
