### PR TITLE
Updated documentation for UpgraderMessages

### DIFF
--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -45,8 +45,10 @@ enum UpgraderMessage {
 ///   @override
 ///   String get buttonTitleIgnore => 'My Ignore';
 /// }
+///
 /// UpgradeAlert(upgrader: Upgrader(messages: MyUpgraderMessages());
 /// ```
+///
 class UpgraderMessages {
   /// The primary language subtag for the locale, which defaults to the
   /// system-reported default locale of the device.

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -45,10 +45,8 @@ enum UpgraderMessage {
 ///   @override
 ///   String get buttonTitleIgnore => 'My Ignore';
 /// }
-///
-/// UpgradeAlert(messages: MyUpgraderMessages());
+/// UpgradeAlert(upgrader: Upgrader(messages: MyUpgraderMessages());
 /// ```
-///
 class UpgraderMessages {
   /// The primary language subtag for the locale, which defaults to the
   /// system-reported default locale of the device.

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -46,7 +46,9 @@ enum UpgraderMessage {
 ///   String get buttonTitleIgnore => 'My Ignore';
 /// }
 ///
-/// UpgradeAlert(upgrader: Upgrader(messages: MyUpgraderMessages());
+/// final upgrader = Upgrader(messages: MyUpgraderMessages());
+/// ...
+/// UpgradeAlert(upgrader: upgrader);
 /// ```
 ///
 class UpgraderMessages {


### PR DESCRIPTION
This is the correct way to override UpgraderMessages, right? I don't see `messages` parameter in `UpgradeAlert`. 

Probably something that changed in recent updates. 