### PR TITLE
Configure `CupertinoActionButton` `isDefaultAction` property when needed

### DIFF
--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -320,13 +320,28 @@ class UpgradeAlertState extends State<UpgradeAlert> {
         )));
     final actions = <Widget>[
       if (showIgnore)
-        button(cupertino, messages.message(UpgraderMessage.buttonTitleIgnore),
-            context, () => onUserIgnored(context, true)),
+        button(
+          cupertino: cupertino,
+          text: messages.message(UpgraderMessage.buttonTitleIgnore),
+          context: context,
+          onPressed: () => onUserIgnored(context, true),
+          isDefaultAction: false,
+        ),
       if (showLater)
-        button(cupertino, messages.message(UpgraderMessage.buttonTitleLater),
-            context, () => onUserLater(context, true)),
-      button(cupertino, messages.message(UpgraderMessage.buttonTitleUpdate),
-          context, () => onUserUpdated(context, !widget.upgrader.blocked())),
+        button(
+          cupertino: cupertino,
+          text: messages.message(UpgraderMessage.buttonTitleLater),
+          context: context,
+          onPressed: () => onUserLater(context, true),
+          isDefaultAction: false,
+        ),
+      button(
+        cupertino: cupertino,
+        text: messages.message(UpgraderMessage.buttonTitleUpdate),
+        context: context,
+        onPressed: () => onUserUpdated(context, !widget.upgrader.blocked()),
+        isDefaultAction: true,
+      ),
     ];
 
     return cupertino
@@ -336,12 +351,18 @@ class UpgradeAlertState extends State<UpgradeAlert> {
             key: key, title: textTitle, content: content, actions: actions);
   }
 
-  Widget button(bool cupertino, String? text, BuildContext context,
-      VoidCallback? onPressed) {
+  Widget button({
+    required bool cupertino,
+    String? text,
+    required BuildContext context,
+    VoidCallback? onPressed,
+    bool isDefaultAction = false,
+  }) {
     return cupertino
         ? CupertinoDialogAction(
             textStyle: widget.cupertinoButtonTextStyle,
             onPressed: onPressed,
+            isDefaultAction: isDefaultAction,
             child: Text(text ?? ''))
         : TextButton(onPressed: onPressed, child: Text(text ?? ''));
   }


### PR DESCRIPTION
**Background:**
When an action in `CupertinoAlertDialog` is configured as the default action using the `isDefaultAction` property, it is shown with a bold textStyle, mimicking the same behavior seen in the native iOS component implementation.

But in `upgrader`, this property is not set appropriately—leaving each action button with identical style, which is not typical on iOS.

**Changes introduced in this PR:**
- This PR configures the `isDefaultAction` property of the `CupertinoAlertDialog` for the "Update" action, whereas it was not set at all before. This results in the "Update" action being shown in a bold font, with no additional / manual textStyle modifications needed.
- Additionally, for clarity, the positional parameters have been changed to named parameters, since we now have multiple bool parameters on the `button` constructor.

Before & After:
<img width="210" alt="before" src="https://github.com/user-attachments/assets/bd6d664b-45fb-43b5-b9b4-68beea799a20">
<img width="215" alt="after" src="https://github.com/user-attachments/assets/526f619e-cf78-49e4-b52b-ae50833d6258">

Please note that the screenshots show custom strings that I've set in my app's specific implementation—these are not included in this PR.