### PR TITLE
Remove the isTooSoon() condition to force users to update

### DIFF
--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -303,7 +303,7 @@ class Upgrader with WidgetsBindingObserver {
       rv = false;
     } else if (isBlocked) {
       rv = true;
-    } else if (isTooSoon() || alreadyIgnoredThisVersion()) {
+    } else if (alreadyIgnoredThisVersion()) {
       rv = false;
     }
     if (state.debugLogging) {


### PR DESCRIPTION
I have removed the isTooSoon() condition to force the user to update in case showIgnore = false and showLater = false. At the same time, it will help fix the error that the update notification does not display again when you restart the application.