### PR TITLE
Feature/upgrade announcer widget

### DIFF
--- a/lib/src/upgrade_announcer.dart
+++ b/lib/src/upgrade_announcer.dart
@@ -91,79 +91,81 @@ class UpgradeAnnouncer extends StatefulWidget {
         useSafeArea: true,
         isScrollControlled: true,
         builder: (BuildContext c) {
-          return FutureBuilder(
-              future: releaseNotes,
-              builder: (context, snapshot) =>
-                  bottomSheetBuilder?.call(
-                    context,
-                    upgrader!.sendUserToAppStore,
-                    releaseNotes,
-                  ) ??
-                  AnimatedContainer(
-                    duration: const Duration(milliseconds: 400),
-                    child: AnimatedCrossFade(
-                        firstChild: SizedBox(
-                          height: 150,
-                          child: Center(
-                            child: CircularProgressIndicator(
-                                color: bottomSheetLoadingIndicatorColor),
-                          ),
-                        ),
-                        secondChild: ConstrainedBox(
-                          constraints: BoxConstraints(
-                              maxHeight: MediaQuery.of(context).size.height *
-                                  bottomSheetMaxHeightFactor),
-                          child: Padding(
-                            padding: const EdgeInsets.only(
-                                top: 20, right: 20, left: 20, bottom: 20),
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
+          return bottomSheetBuilder?.call(
+                context,
+                upgrader!.sendUserToAppStore,
+                releaseNotes,
+              ) ??
+              FutureBuilder(
+                  future: releaseNotes,
+                  builder: (context, snapshot) => AnimatedContainer(
+                        duration: const Duration(milliseconds: 400),
+                        child: AnimatedCrossFade(
+                            firstChild: SizedBox(
+                              height: 150,
+                              child: Center(
+                                child: CircularProgressIndicator(
+                                    color: bottomSheetLoadingIndicatorColor),
+                              ),
+                            ),
+                            secondChild: ConstrainedBox(
+                              constraints: BoxConstraints(
+                                  maxHeight:
+                                      MediaQuery.of(context).size.height *
+                                          bottomSheetMaxHeightFactor),
+                              child: Padding(
+                                padding: const EdgeInsets.only(
+                                    top: 20, right: 20, left: 20, bottom: 20),
+                                child: Column(
+                                  mainAxisSize: MainAxisSize.min,
+                                  crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
-                                    Text(
-                                      upgrader!
-                                          .determineMessages(context)
-                                          .newInThisVersion,
-                                      style: bottomSheetTitleTextStyle ??
-                                          const TextStyle(
-                                              fontSize: 20,
-                                              fontWeight: FontWeight.w600),
+                                    Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        Text(
+                                          upgrader!
+                                              .determineMessages(context)
+                                              .newInThisVersion,
+                                          style: bottomSheetTitleTextStyle ??
+                                              const TextStyle(
+                                                  fontSize: 20,
+                                                  fontWeight: FontWeight.w600),
+                                        ),
+                                        if (showDownloadIcon)
+                                          IconButton(
+                                            onPressed:
+                                                upgrader.sendUserToAppStore,
+                                            icon: Icon(
+                                                downloadIcon ?? Icons.download,
+                                                color: downloadIconColor),
+                                          )
+                                      ],
                                     ),
-                                    if (showDownloadIcon)
-                                      IconButton(
-                                        onPressed: upgrader.sendUserToAppStore,
-                                        icon: Icon(
-                                            downloadIcon ?? Icons.download,
-                                            color: downloadIconColor),
-                                      )
+                                    Flexible(
+                                      child: SingleChildScrollView(
+                                        child: Text(
+                                          style:
+                                              bottomSheetReleaseNotesTextStyle ??
+                                                  const TextStyle(fontSize: 14),
+                                          snapshot.data ??
+                                              upgrader
+                                                  .determineMessages(context)
+                                                  .noAvailableReleaseNotes,
+                                        ),
+                                      ),
+                                    ),
                                   ],
                                 ),
-                                Flexible(
-                                  child: SingleChildScrollView(
-                                    child: Text(
-                                      style: bottomSheetReleaseNotesTextStyle ??
-                                          const TextStyle(fontSize: 14),
-                                      snapshot.data ??
-                                          upgrader
-                                              .determineMessages(context)
-                                              .noAvailableReleaseNotes,
-                                    ),
-                                  ),
-                                ),
-                              ],
+                              ),
                             ),
-                          ),
-                        ),
-                        crossFadeState:
-                            snapshot.connectionState == ConnectionState.waiting
+                            crossFadeState: snapshot.connectionState ==
+                                    ConnectionState.waiting
                                 ? CrossFadeState.showFirst
                                 : CrossFadeState.showSecond,
-                        duration: const Duration(milliseconds: 500)),
-                  ));
+                            duration: const Duration(milliseconds: 500)),
+                      ));
         },
       );
     }

--- a/lib/src/upgrade_announcer.dart
+++ b/lib/src/upgrade_announcer.dart
@@ -1,0 +1,164 @@
+import 'package:flutter/material.dart';
+import 'package:upgrader/upgrader.dart';
+
+class UpgradeAnnouncer extends StatefulWidget {
+  final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey;
+  final Color? backgroundColor;
+  final Color? bottomSheetBackgroundColor;
+  final Widget Function(
+          BuildContext context, Upgrader upgrader, String releaseNotes)?
+      bottomSheetBuilder;
+  final TextStyle? titleTextStyle;
+  final TextStyle? bottomSheetTitleTextStyle;
+  final TextStyle? bottomSheetReleaseNotesTextStyle;
+  final IconData? infoIcon;
+  final Color? infoIconColor;
+  final IconData? downloadIcon;
+  final Color? downloadIconColor;
+  final Widget child;
+
+  const UpgradeAnnouncer({
+    super.key,
+    required this.scaffoldMessengerKey,
+    this.backgroundColor,
+    this.bottomSheetBackgroundColor,
+    this.bottomSheetBuilder,
+    this.titleTextStyle,
+    this.bottomSheetTitleTextStyle,
+    this.bottomSheetReleaseNotesTextStyle,
+    this.infoIcon,
+    this.infoIconColor,
+    this.downloadIcon,
+    this.downloadIconColor,
+    required this.child,
+  });
+
+  @override
+  State<StatefulWidget> createState() => _UpgradeAnnouncer();
+}
+
+class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
+  final _upgrader = Upgrader();
+
+  @override
+  void initState() {
+    _checkForUpgrade();
+
+    AppLifecycleListener(onResume: () {
+      _checkForUpgrade(dismissMaterialBanners: true);
+    });
+
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+
+  _checkForUpgrade({bool dismissMaterialBanners = false}) {
+    _upgrader.initialize().then((initialized) async {
+      final versionInfo = await _upgrader.updateVersionInfo();
+      final appStoreVersion = versionInfo?.appStoreVersion;
+      final installedVersion = versionInfo?.installedVersion;
+      final releaseNotes = versionInfo?.releaseNotes;
+
+      if (true) {
+        if (true) {
+          if (dismissMaterialBanners) {
+            widget.scaffoldMessengerKey.currentState?.clearMaterialBanners();
+          }
+
+          widget.scaffoldMessengerKey.currentState?.showMaterialBanner(
+            MaterialBanner(
+              content: Builder(
+                builder: (context) => TextButton(
+                  onPressed: mounted
+                      ? () => _infoBottomSheet(context, releaseNotes, _upgrader)
+                      : null,
+                  child: Row(
+                    children: [
+                      Icon(widget.infoIcon ?? Icons.info_outline,
+                          color: widget.infoIconColor ?? Colors.white),
+                      const SizedBox(width: 8),
+                      Text(
+                        UpgraderMessages().upgradeAvailable,
+                        style: widget.titleTextStyle ??
+                            const TextStyle(color: Colors.white),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              backgroundColor: widget.backgroundColor ?? Colors.green,
+              actions: <Widget>[
+                TextButton(
+                  onPressed: _upgrader.sendUserToAppStore,
+                  child: Icon(widget.downloadIcon ?? Icons.download,
+                      color: widget.downloadIconColor ?? Colors.white),
+                ),
+              ],
+            ),
+          );
+        }
+      }
+    });
+  }
+
+  _infoBottomSheet(
+      BuildContext context, String? releaseNotes, Upgrader upgrader) {
+    if (releaseNotes == null) return;
+    showModalBottomSheet(
+      backgroundColor: widget.bottomSheetBackgroundColor,
+      context: context,
+      enableDrag: false,
+      builder: (BuildContext c) {
+        return widget.bottomSheetBuilder?.call(
+              context,
+              upgrader,
+              releaseNotes,
+            ) ??
+            ConstrainedBox(
+              constraints: BoxConstraints(
+                  maxHeight: MediaQuery.of(context).size.height * .5),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        UpgraderMessages().newInThisVersion,
+                        style: widget.bottomSheetTitleTextStyle ??
+                            const TextStyle(
+                                color: Colors.white,
+                                fontSize: 20,
+                                fontWeight: FontWeight.w600),
+                      ),
+                      IconButton(
+                        onPressed: upgrader.sendUserToAppStore,
+                        icon: Icon(widget.downloadIcon ?? Icons.download,
+                            color: widget.downloadIconColor ?? Colors.white),
+                      )
+                    ],
+                  ),
+                  Flexible(
+                    child: SingleChildScrollView(
+                      child: Text(
+                        style: widget.bottomSheetTitleTextStyle ??
+                            const TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                            ),
+                        releaseNotes, // TODO: Create translation
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+      },
+    );
+  }
+}

--- a/lib/src/upgrade_announcer.dart
+++ b/lib/src/upgrade_announcer.dart
@@ -3,22 +3,32 @@ import 'package:upgrader/upgrader.dart';
 
 typedef UpgradeAnnouncerBottomSheetBuilder = Widget Function(
     BuildContext context, VoidCallback goToAppStore, String? releaseNotes);
+typedef UpgradeAnnouncerEnforceUpgradeBuilder = Widget Function(
+    BuildContext context, VoidCallback goToAppStore);
 
 class UpgradeAnnouncer extends StatefulWidget {
   final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey;
   final Upgrader? upgrader;
+  final UpgradeAnnouncerBottomSheetBuilder? bottomSheetBuilder;
   final Color? backgroundColor;
   final double bottomSheetHeightFactor;
   final Color? bottomSheetBackgroundColor;
-  final UpgradeAnnouncerBottomSheetBuilder? bottomSheetBuilder;
   final TextStyle? bottomSheetTitleTextStyle;
   final TextStyle? bottomSheetReleaseNotesTextStyle;
+  final UpgradeAnnouncerEnforceUpgradeBuilder? enforceUpgradeBuilder;
+  final Color? enforceUpgradeBackgroundColor;
+  final TextStyle? enforceUpgradeTextStyle;
   final TextStyle? titleTextStyle;
   final IconData? infoIcon;
   final Color? infoIconColor;
   final IconData? downloadIcon;
   final Color? downloadIconColor;
-  final bool forceShow;
+
+  /// When set to true this will enforce an upgrade based on the
+  /// [Upgrader.minAppVersion] version
+  final bool enforceUpgrade;
+  final bool debugEnforceUpgrade;
+  final bool debugUpgrade;
   final Widget child;
 
   const UpgradeAnnouncer({
@@ -26,17 +36,22 @@ class UpgradeAnnouncer extends StatefulWidget {
     required this.scaffoldMessengerKey,
     this.upgrader,
     this.backgroundColor,
+    this.bottomSheetBuilder,
     this.bottomSheetHeightFactor = .6,
     this.bottomSheetBackgroundColor,
-    this.bottomSheetBuilder,
     this.bottomSheetTitleTextStyle,
     this.bottomSheetReleaseNotesTextStyle,
+    this.enforceUpgradeBuilder,
+    this.enforceUpgradeBackgroundColor,
+    this.enforceUpgradeTextStyle,
     this.titleTextStyle,
     this.infoIcon,
     this.infoIconColor,
     this.downloadIcon,
     this.downloadIconColor,
-    this.forceShow = false,
+    this.enforceUpgrade = false,
+    this.debugEnforceUpgrade = false,
+    this.debugUpgrade = false,
     required this.child,
   });
 
@@ -46,6 +61,8 @@ class UpgradeAnnouncer extends StatefulWidget {
 
 class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
   late final _upgrader = widget.upgrader ?? Upgrader();
+
+  bool _shouldEnforceUpgrade = false;
 
   @override
   void initState() {
@@ -60,61 +77,153 @@ class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
 
   @override
   Widget build(BuildContext context) {
-    return widget.child;
+    return Stack(
+      children: [
+        AbsorbPointer(absorbing: _shouldEnforceUpgrade, child: widget.child),
+        if (_shouldEnforceUpgrade)
+          Container(
+            color: Colors.black.withOpacity(.5),
+          ),
+        if (_shouldEnforceUpgrade)
+          Material(
+            color: Colors.transparent,
+            child: widget.enforceUpgradeBuilder
+                    ?.call(context, _upgrader.sendUserToAppStore) ??
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(50.0),
+                    child: Container(
+                      decoration: BoxDecoration(
+                          color: widget.enforceUpgradeBackgroundColor ??
+                              Theme.of(context).canvasColor,
+                          borderRadius: BorderRadius.circular(16)),
+                      child: Padding(
+                        padding: const EdgeInsets.all(32.0),
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Row(
+                              children: [
+                                Icon(widget.infoIcon ?? Icons.info_outline,
+                                    color: widget.infoIconColor),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    UpgraderMessages().upgradeEnforce,
+                                    style: widget.enforceUpgradeTextStyle ??
+                                        const TextStyle(
+                                          fontSize: 14,
+                                        ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                            const Padding(padding: EdgeInsets.all(16)),
+                            Material(
+                              child: InkWell(
+                                borderRadius: BorderRadius.circular(16),
+                                onTap: _upgrader.sendUserToAppStore,
+                                child: Padding(
+                                  padding: const EdgeInsets.all(8.0),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    mainAxisAlignment: MainAxisAlignment.center,
+                                    children: [
+                                      Text(
+                                        UpgraderMessages().buttonTitleUpdate,
+                                        style: widget.enforceUpgradeTextStyle ??
+                                            const TextStyle(
+                                                fontSize: 14,
+                                                fontWeight: FontWeight.w600),
+                                      ),
+                                      const Padding(padding: EdgeInsets.all(2)),
+                                      Icon(
+                                          widget.downloadIcon ?? Icons.download,
+                                          color: widget.downloadIconColor),
+                                    ],
+                                  ),
+                                ),
+                              ),
+                            )
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                ),
+          )
+      ],
+    );
   }
 
-  _checkForUpgrade({bool dismissMaterialBanners = false}) {
+  void _checkForUpgrade({bool dismissMaterialBanners = false}) {
     _upgrader.initialize().then((initialized) async {
       final versionInfo = await _upgrader.updateVersionInfo();
       final appStoreVersion = versionInfo?.appStoreVersion;
       final installedVersion = versionInfo?.installedVersion;
       final releaseNotes = versionInfo?.releaseNotes;
+      final minAppVersion = _upgrader.versionInfo?.minAppVersion;
 
       if (versionInfo != null &&
           appStoreVersion != null &&
           installedVersion != null) {
-        if (appStoreVersion > installedVersion || widget.forceShow) {
-          if (dismissMaterialBanners) {
-            widget.scaffoldMessengerKey.currentState?.clearMaterialBanners();
+        if (appStoreVersion > installedVersion ||
+            (widget.debugUpgrade || widget.debugEnforceUpgrade)) {
+          if (widget.enforceUpgrade || widget.debugEnforceUpgrade) {
+            setState(() {
+              _shouldEnforceUpgrade =
+                  minAppVersion != null && minAppVersion > installedVersion ||
+                      widget.debugEnforceUpgrade;
+            });
           }
 
-          widget.scaffoldMessengerKey.currentState?.showMaterialBanner(
-            MaterialBanner(
-              content: Builder(
-                builder: (context) => TextButton(
-                  onPressed: mounted
-                      ? () => _showBottomSheet(context, releaseNotes, _upgrader)
-                      : null,
-                  child: Row(
-                    children: [
-                      Icon(widget.infoIcon ?? Icons.info_outline,
-                          color: widget.infoIconColor ?? Colors.white),
-                      const SizedBox(width: 8),
-                      Text(
-                        UpgraderMessages().upgradeAvailable,
-                        style: widget.titleTextStyle ??
-                            const TextStyle(color: Colors.white),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-              backgroundColor: widget.backgroundColor ?? Colors.green,
-              actions: <Widget>[
-                IconButton(
-                  onPressed: _upgrader.sendUserToAppStore,
-                  icon: Icon(widget.downloadIcon ?? Icons.download,
-                      color: widget.downloadIconColor ?? Colors.white),
-                ),
-              ],
-            ),
-          );
+          _showMaterialBanner(dismissMaterialBanners, releaseNotes);
         }
       }
     });
   }
 
-  _showBottomSheet(
+  void _showMaterialBanner(bool dismissMaterialBanners, String? releaseNotes) {
+    if (!_shouldEnforceUpgrade) {
+      if (dismissMaterialBanners) {
+        widget.scaffoldMessengerKey.currentState?.clearMaterialBanners();
+      }
+
+      widget.scaffoldMessengerKey.currentState?.showMaterialBanner(
+        MaterialBanner(
+          content: Builder(
+            builder: (context) => TextButton(
+              onPressed: mounted
+                  ? () => _showBottomSheet(context, releaseNotes, _upgrader)
+                  : null,
+              child: Row(
+                children: [
+                  Icon(widget.infoIcon ?? Icons.info_outline,
+                      color: widget.infoIconColor ?? Colors.white),
+                  const SizedBox(width: 8),
+                  Text(
+                    UpgraderMessages().upgradeAvailable,
+                    style: widget.titleTextStyle ??
+                        const TextStyle(color: Colors.white),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          backgroundColor: widget.backgroundColor ?? Colors.green,
+          actions: <Widget>[
+            IconButton(
+              onPressed: _upgrader.sendUserToAppStore,
+              icon: Icon(widget.downloadIcon ?? Icons.download,
+                  color: widget.downloadIconColor ?? Colors.white),
+            ),
+          ],
+        ),
+      );
+    }
+  }
+
+  void _showBottomSheet(
       BuildContext context, String? releaseNotes, Upgrader upgrader) {
     showModalBottomSheet(
       backgroundColor: widget.bottomSheetBackgroundColor,

--- a/lib/src/upgrade_announcer.dart
+++ b/lib/src/upgrade_announcer.dart
@@ -132,6 +132,7 @@ class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
                   maxHeight: MediaQuery.of(context).size.height *
                       widget.bottomSheetHeightFactor),
               child: Column(
+                mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Padding(

--- a/lib/src/upgrade_announcer.dart
+++ b/lib/src/upgrade_announcer.dart
@@ -83,7 +83,7 @@ class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
               content: Builder(
                 builder: (context) => TextButton(
                   onPressed: mounted
-                      ? () => _infoBottomSheet(context, releaseNotes, _upgrader)
+                      ? () => _showBottomSheet(context, releaseNotes, _upgrader)
                       : null,
                   child: Row(
                     children: [
@@ -114,7 +114,7 @@ class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
     });
   }
 
-  _infoBottomSheet(
+  _showBottomSheet(
       BuildContext context, String? releaseNotes, Upgrader upgrader) {
     showModalBottomSheet(
       backgroundColor: widget.bottomSheetBackgroundColor,

--- a/lib/src/upgrade_announcer.dart
+++ b/lib/src/upgrade_announcer.dart
@@ -28,7 +28,7 @@ class UpgradeAnnouncer extends StatefulWidget {
   /// [Upgrader.minAppVersion] version
   final bool enforceUpgrade;
   final bool debugEnforceUpgrade;
-  final bool debugUpgrade;
+  final bool debugAvailableUpgrade;
   final Widget child;
 
   const UpgradeAnnouncer({
@@ -51,7 +51,7 @@ class UpgradeAnnouncer extends StatefulWidget {
     this.downloadIconColor,
     this.enforceUpgrade = false,
     this.debugEnforceUpgrade = false,
-    this.debugUpgrade = false,
+    this.debugAvailableUpgrade = false,
     required this.child,
   });
 
@@ -168,7 +168,7 @@ class _UpgradeAnnouncer extends State<UpgradeAnnouncer> {
           appStoreVersion != null &&
           installedVersion != null) {
         if (appStoreVersion > installedVersion ||
-            (widget.debugUpgrade || widget.debugEnforceUpgrade)) {
+            (widget.debugAvailableUpgrade || widget.debugEnforceUpgrade)) {
           if (widget.enforceUpgrade || widget.debugEnforceUpgrade) {
             setState(() {
               _shouldEnforceUpgrade =

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -96,6 +96,16 @@ class UpgraderMessages {
     return code;
   }
 
+  String get upgradeAvailable => switch (languageCode) {
+        'da' => 'Ny opdatering tilgængelig!',
+        _ => 'New update available!',
+      };
+
+  String get newInThisVersion => switch (languageCode) {
+        'da' => 'Nyt i denne version',
+        _ => 'New in this version',
+      };
+
   /// The body of the upgrade message. This string supports mustache style
   /// template variables:
   ///   {{appName}}

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -106,6 +106,11 @@ class UpgraderMessages {
         _ => 'New in this version',
       };
 
+  String get noAvailableReleaseNotes => switch (languageCode) {
+        'da' => 'Ingen tilgængelige udgivelsesnoter',
+        _ => 'No available release notes',
+      };
+
   /// The body of the upgrade message. This string supports mustache style
   /// template variables:
   ///   {{appName}}

--- a/lib/src/upgrade_messages.dart
+++ b/lib/src/upgrade_messages.dart
@@ -111,6 +111,11 @@ class UpgraderMessages {
         _ => 'No available release notes',
       };
 
+  String get upgradeEnforce => switch (languageCode) {
+        'da' => 'En opdatering er påkrævet før at du kan benytte app\'en',
+        _ => 'An update is required before you can use the app.',
+      };
+
   /// The body of the upgrade message. This string supports mustache style
   /// template variables:
   ///   {{appName}}

--- a/lib/upgrader.dart
+++ b/lib/upgrader.dart
@@ -9,6 +9,7 @@ export 'src/appcast.dart';
 export 'src/itunes_search_api.dart';
 export 'src/play_store_search_api.dart';
 export 'src/upgrade_alert.dart';
+export 'src/upgrade_announcer.dart';
 export 'src/upgrade_card.dart';
 export 'src/upgrade_device.dart';
 export 'src/upgrade_messages.dart';

--- a/test/upgrade_announcer_google_play_test.dart
+++ b/test/upgrade_announcer_google_play_test.dart
@@ -6,7 +6,7 @@ import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:upgrader/upgrader.dart';
 
-import 'mock_itunes_client.dart';
+import 'mock_play_store_client.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -22,13 +22,13 @@ void main() {
     return true;
   });
 
-  group("UpgradeAnnouncer", () {
+  group("UpgradeAnnouncer with Google Play", () {
     testWidgets('Upgrade enforce; always shown; debugEnforceUpgrade',
         (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -36,8 +36,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '5.6',
+        packageName: 'com.testing.test2',
+        version: '2.0.2',
         buildNumber: '400',
       ));
 
@@ -66,10 +66,10 @@ void main() {
 
     testWidgets('Upgrade available; always shown; debugAvailableUpgrade',
         (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -77,8 +77,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '5.6',
+        packageName: 'com.testing.test2',
+        version: '2.0.2',
         buildNumber: '400',
       ));
 
@@ -106,10 +106,10 @@ void main() {
     }, skip: false);
 
     testWidgets('No upgrade available', (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -117,8 +117,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '5.6',
+        packageName: 'com.testing.test2',
+        version: '2.0.2',
         buildNumber: '400',
       ));
 
@@ -145,10 +145,10 @@ void main() {
     }, skip: false);
 
     testWidgets('Upgrade available', (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -156,8 +156,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -209,10 +209,10 @@ void main() {
 
     testWidgets('Upgrade available; bottomSheetBuilder',
         (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -220,8 +220,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -282,10 +282,10 @@ void main() {
 
     testWidgets('Upgrade available; icons, styles and colors',
         (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -293,8 +293,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -312,7 +312,6 @@ void main() {
       const bottomSheetReleaseNotesTextStyle =
           TextStyle(color: Colors.purple, fontSize: 30);
       const bottomSheetBackgroundColor = Colors.teal;
-      const bottomSheetLoadingIndicatorColor = Colors.amber;
 
       final testWidget = MaterialApp(
         scaffoldMessengerKey: rootScaffoldMessengerKey,
@@ -327,7 +326,6 @@ void main() {
           bottomSheetTitleTextStyle: bottomSheetTitleTextStyle,
           bottomSheetReleaseNotesTextStyle: bottomSheetReleaseNotesTextStyle,
           bottomSheetBackgroundColor: bottomSheetBackgroundColor,
-          bottomSheetLoadingIndicatorColor: bottomSheetLoadingIndicatorColor,
           upgrader: upgrader,
           child: Scaffold(
             body: const Placeholder(),
@@ -394,19 +392,14 @@ void main() {
                 themeData.backgroundColor == bottomSheetBackgroundColor,
           ),
           findsOneWidget);
-      expect(
-          find.byWidgetPredicate((widget) =>
-              widget is CircularProgressIndicator &&
-              widget.color == bottomSheetLoadingIndicatorColor),
-          findsOneWidget);
     }, skip: false);
 
     testWidgets('Upgrade available; release notes in bottom sheet',
         (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -414,8 +407,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -450,11 +443,10 @@ void main() {
 
     testWidgets('Upgrade available; no enforce upgrade',
         (WidgetTester tester) async {
-      final client =
-          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -462,8 +454,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -492,11 +484,10 @@ void main() {
 
     testWidgets('Upgrade available; enforce upgrade',
         (WidgetTester tester) async {
-      final client =
-          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -504,8 +495,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -534,11 +525,10 @@ void main() {
 
     testWidgets('Upgrade available; enforce upgrade; enforceUpgradeBuilder',
         (WidgetTester tester) async {
-      final client =
-          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -546,8 +536,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -588,11 +578,10 @@ void main() {
 
     testWidgets('Upgrade available; enforce upgrade; icons, styles and colors',
         (WidgetTester tester) async {
-      final client =
-          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -600,8 +589,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '0.9.9',
+        packageName: 'com.testing.test2',
+        version: '2.0.0',
         buildNumber: '400',
       ));
 
@@ -669,10 +658,10 @@ void main() {
 
     testWidgets('Show release notes in bottom sheet',
         (WidgetTester tester) async {
-      final client = MockITunesSearchClient.setupMockClient();
+      final client = await MockPlayStoreSearchClient.setupMockClient();
 
       final upgrader = Upgrader(
-        upgraderOS: MockUpgraderOS(ios: true),
+        upgraderOS: MockUpgraderOS(android: true),
         client: client,
         debugLogging: true,
       );
@@ -680,8 +669,8 @@ void main() {
       upgrader.installPackageInfo(
           packageInfo: PackageInfo(
         appName: 'Upgrader',
-        packageName: 'com.larryaasen.upgrader',
-        version: '5.6',
+        packageName: 'com.testing.test2',
+        version: '2.0.2',
         buildNumber: '400',
       ));
 

--- a/test/upgrade_announcer_test.dart
+++ b/test/upgrade_announcer_test.dart
@@ -64,7 +64,7 @@ void main() {
       expect(find.text(UpgraderMessages().upgradeEnforce), findsOneWidget);
     }, skip: false);
 
-    testWidgets('Upgrade available; always shown; debugUpgrade',
+    testWidgets('Upgrade available; always shown; debugAvailableUpgrade',
         (WidgetTester tester) async {
       final client = MockITunesSearchClient.setupMockClient();
 
@@ -90,7 +90,7 @@ void main() {
         home: UpgradeAnnouncer(
           scaffoldMessengerKey: rootScaffoldMessengerKey,
           upgrader: upgrader,
-          debugUpgrade: true,
+          debugAvailableUpgrade: true,
           child: Scaffold(
             body: const Placeholder(),
             appBar: AppBar(title: const Text('Upgrader test')),

--- a/test/upgrade_announcer_test.dart
+++ b/test/upgrade_announcer_test.dart
@@ -1,0 +1,392 @@
+// Copyright (c) 2024 Larry Aasen. All rights reserved.
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:upgrader/upgrader.dart';
+
+import 'mock_itunes_client.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late SharedPreferences preferences;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    preferences = await SharedPreferences.getInstance();
+  });
+
+  tearDown(() async {
+    await preferences.clear();
+    return true;
+  });
+  group("UpgradeAnnouncer", () {
+    testWidgets('Upgrade available always shown; forceShow',
+        (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '5.6',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          forceShow: true,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+    }, skip: false);
+
+    testWidgets('No upgrade available', (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '5.6',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsNothing);
+    }, skip: false);
+
+    testWidgets('Upgrade available', (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is MaterialBanner &&
+              widget.backgroundColor == Colors.green),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == Icons.info_outline &&
+              widget.color == Colors.white),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == Icons.download &&
+              widget.color == Colors.white),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              widget.data == UpgraderMessages().upgradeAvailable &&
+              widget.style?.color == Colors.white),
+          findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; bottomSheetBuilder',
+        (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      const bottomSheetContainerColor = Colors.teal;
+      const bottomSheetBuilderTextStyle =
+          TextStyle(color: Colors.yellow, fontSize: 12);
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          bottomSheetBuilder: (context, goToAppStore, releaseNotes) =>
+              Container(
+            color: bottomSheetContainerColor,
+            child: Text(
+              releaseNotes!,
+              style: bottomSheetBuilderTextStyle,
+            ),
+          ),
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+
+      await tester.tap(find.text(UpgraderMessages().upgradeAvailable));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Container &&
+                widget.color == bottomSheetContainerColor,
+          ),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate(
+            (widget) =>
+                widget is Text && widget.style == bottomSheetBuilderTextStyle,
+          ),
+          findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; icons, styles and colors',
+        (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      const backgroundColor = Colors.red;
+      const infoIcon = Icons.add;
+      const infoIconColor = Colors.blue;
+      const downloadIcon = Icons.abc;
+      const downloadIconColor = Colors.yellow;
+      const titleTextStyle = TextStyle(color: Colors.amber, fontSize: 20);
+      const bottomSheetTitleTextStyle =
+          TextStyle(color: Colors.orange, fontSize: 25);
+      const bottomSheetReleaseNotesTextStyle =
+          TextStyle(color: Colors.purple, fontSize: 30);
+      const bottomSheetBackgroundColor = Colors.teal;
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          backgroundColor: backgroundColor,
+          infoIcon: infoIcon,
+          infoIconColor: infoIconColor,
+          downloadIcon: downloadIcon,
+          downloadIconColor: downloadIconColor,
+          titleTextStyle: titleTextStyle,
+          bottomSheetTitleTextStyle: bottomSheetTitleTextStyle,
+          bottomSheetReleaseNotesTextStyle: bottomSheetReleaseNotesTextStyle,
+          bottomSheetBackgroundColor: bottomSheetBackgroundColor,
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is MaterialBanner &&
+              widget.backgroundColor == backgroundColor),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == infoIcon &&
+              widget.color == infoIconColor),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == downloadIcon &&
+              widget.color == downloadIconColor),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              widget.data == UpgraderMessages().upgradeAvailable &&
+              widget.style == titleTextStyle),
+          findsOneWidget);
+
+      await tester.tap(find.text(UpgraderMessages().upgradeAvailable));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == downloadIcon &&
+              widget.color == downloadIconColor),
+          findsNWidgets(2));
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              widget.data == UpgraderMessages().newInThisVersion &&
+              widget.style == bottomSheetTitleTextStyle),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              widget.data == upgrader.releaseNotes &&
+              widget.style == bottomSheetReleaseNotesTextStyle),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate(
+            (themeData) =>
+                themeData is BottomSheet &&
+                themeData.backgroundColor == bottomSheetBackgroundColor,
+          ),
+          findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; release notes in bottom sheet',
+        (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+
+      await tester.tap(find.text(UpgraderMessages().upgradeAvailable));
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().newInThisVersion), findsOneWidget);
+      expect(find.byIcon(Icons.download), findsNWidgets(2));
+      expect(find.text(upgrader.releaseNotes!), findsOneWidget);
+    }, skip: false);
+  });
+}

--- a/test/upgrade_announcer_test.dart
+++ b/test/upgrade_announcer_test.dart
@@ -21,8 +21,9 @@ void main() {
     await preferences.clear();
     return true;
   });
+
   group("UpgradeAnnouncer", () {
-    testWidgets('Upgrade available always shown; forceShow',
+    testWidgets('Upgrade enforce; always shown; debugEnforceUpgrade',
         (WidgetTester tester) async {
       final client = MockITunesSearchClient.setupMockClient();
 
@@ -48,7 +49,48 @@ void main() {
         home: UpgradeAnnouncer(
           scaffoldMessengerKey: rootScaffoldMessengerKey,
           upgrader: upgrader,
-          forceShow: true,
+          debugEnforceUpgrade: true,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsNothing);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; always shown; debugUpgrade',
+        (WidgetTester tester) async {
+      final client = MockITunesSearchClient.setupMockClient();
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '5.6',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          debugUpgrade: true,
           child: Scaffold(
             body: const Placeholder(),
             appBar: AppBar(title: const Text('Upgrader test')),
@@ -60,6 +102,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
     }, skip: false);
 
     testWidgets('No upgrade available', (WidgetTester tester) async {
@@ -98,6 +141,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.text(UpgraderMessages().upgradeAvailable), findsNothing);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
     }, skip: false);
 
     testWidgets('Upgrade available', (WidgetTester tester) async {
@@ -136,6 +180,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
 
       expect(
           find.byWidgetPredicate((widget) =>
@@ -211,6 +256,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
 
       await tester.tap(find.text(UpgraderMessages().upgradeAvailable));
       await tester.pumpAndSettle(const Duration(seconds: 1));
@@ -288,6 +334,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
 
       expect(
           find.byWidgetPredicate((widget) =>
@@ -380,6 +427,7 @@ void main() {
       await tester.pumpAndSettle(const Duration(seconds: 1));
 
       expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
 
       await tester.tap(find.text(UpgraderMessages().upgradeAvailable));
       await tester.pumpAndSettle(const Duration(seconds: 1));
@@ -387,6 +435,225 @@ void main() {
       expect(find.text(UpgraderMessages().newInThisVersion), findsOneWidget);
       expect(find.byIcon(Icons.download), findsNWidgets(2));
       expect(find.text(upgrader.releaseNotes!), findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; no enforce upgrade',
+        (WidgetTester tester) async {
+      final client =
+          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          enforceUpgrade: false,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 3));
+
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; enforce upgrade',
+        (WidgetTester tester) async {
+      final client =
+          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          upgrader: upgrader,
+          enforceUpgrade: true,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 3));
+
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsOneWidget);
+      expect(find.text(UpgraderMessages().upgradeAvailable), findsNothing);
+    }, skip: false);
+
+    testWidgets('Upgrade available; enforce upgrade; enforceUpgradeBuilder',
+        (WidgetTester tester) async {
+      final client =
+          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      const enforceUpgradeBuilderContainerColor = Colors.teal;
+      const enforceUpgradeBuilderText = 'Testing builder';
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          enforceUpgradeBuilder: (context, _) => Container(
+            color: enforceUpgradeBuilderContainerColor,
+            child: const Text(enforceUpgradeBuilderText),
+          ),
+          enforceUpgrade: true,
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsNothing);
+
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Container &&
+              widget.color == enforceUpgradeBuilderContainerColor),
+          findsOneWidget);
+      expect(find.text(enforceUpgradeBuilderText), findsOneWidget);
+    }, skip: false);
+
+    testWidgets('Upgrade available; enforce upgrade; icons, styles and colors',
+        (WidgetTester tester) async {
+      final client =
+          MockITunesSearchClient.setupMockClient(description: '[:mav: 5.7]');
+
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.larryaasen.upgrader',
+        version: '0.9.9',
+        buildNumber: '400',
+      ));
+
+      final GlobalKey<ScaffoldMessengerState> rootScaffoldMessengerKey =
+          GlobalKey<ScaffoldMessengerState>();
+
+      const infoIcon = Icons.add;
+      const infoIconColor = Colors.blue;
+      const downloadIcon = Icons.abc;
+      const downloadIconColor = Colors.yellow;
+      const enforceUpgradeBackgroundColor = Colors.red;
+      const enforceUpgradeTextStyle =
+          TextStyle(color: Colors.amber, fontSize: 20);
+      final testWidget = MaterialApp(
+        scaffoldMessengerKey: rootScaffoldMessengerKey,
+        home: UpgradeAnnouncer(
+          scaffoldMessengerKey: rootScaffoldMessengerKey,
+          infoIcon: infoIcon,
+          infoIconColor: infoIconColor,
+          downloadIcon: downloadIcon,
+          downloadIconColor: downloadIconColor,
+          enforceUpgradeBackgroundColor: enforceUpgradeBackgroundColor,
+          enforceUpgradeTextStyle: enforceUpgradeTextStyle,
+          enforceUpgrade: true,
+          upgrader: upgrader,
+          child: Scaffold(
+            body: const Placeholder(),
+            appBar: AppBar(title: const Text('Upgrader test')),
+          ),
+        ),
+      );
+
+      await tester.pumpWidget(testWidget);
+      await tester.pumpAndSettle(const Duration(seconds: 1));
+
+      expect(find.text(UpgraderMessages().upgradeEnforce), findsOneWidget);
+
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Container &&
+              widget.decoration ==
+                  BoxDecoration(
+                      color: enforceUpgradeBackgroundColor,
+                      borderRadius: BorderRadius.circular(16))),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == infoIcon &&
+              widget.color == infoIconColor),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Icon &&
+              widget.icon == downloadIcon &&
+              widget.color == downloadIconColor),
+          findsOneWidget);
+      expect(
+          find.byWidgetPredicate((widget) =>
+              widget is Text &&
+              widget.data == UpgraderMessages().upgradeEnforce &&
+              widget.style == enforceUpgradeTextStyle),
+          findsOneWidget);
     }, skip: false);
   });
 }


### PR DESCRIPTION
Add `UpgradeAnnouncer` widget. This widget should be used at the top of the widget tree just below `MaterialApp`. Uses a `MaterialBanner` with `showMaterialBanner`. We utilize the `scaffoldMessengerKey`  to make this possible.

This has a distinct advantage over the `UpgradeAlert` as the `MaterialBanner` is shown globally; also during navigation.

This is the `MaterialBanner` shown globally;

![image](https://github.com/user-attachments/assets/ac2ee9a6-ffd8-47a2-8832-5518f81230fc)

When the `MaterialBanner` is tapped a bottom sheet is shown with the appropriate release notes;

![screenshot-1](https://github.com/user-attachments/assets/e31b5770-dea4-4e33-bbf4-a0a44aa392b9)

The  `UpgradeAnnouncer` also supports what is called `enforceUpgrade` which uses the `Upgrader.minAppVersion` to enforce an update if the current version is lower. This presents a dialog that cannot be dismissed; similar to what the `UpgradeAlert` supports;
![image](https://github.com/user-attachments/assets/9bda2d84-0c22-4807-a34f-33aa7ebd9162)


Simple example of usage;
```
      MaterialApp(
        scaffoldMessengerKey: rootScaffoldMessengerKey,
        home: UpgradeAnnouncer(
          scaffoldMessengerKey: rootScaffoldMessengerKey,
          child: Scaffold(
            body: const Placeholder(),
            appBar: AppBar(title: const Text('Upgrader test')),
          ),
        ),
      );
```

Example with customizable icons, text styles and colors;
```
      const backgroundColor = Colors.red;
      const infoIcon = Icons.add;
      const infoIconColor = Colors.blue;
      const downloadIcon = Icons.abc;
      const downloadIconColor = Colors.yellow;
      const titleTextStyle = TextStyle(color: Colors.amber, fontSize: 20);
      const bottomSheetTitleTextStyle =
          TextStyle(color: Colors.orange, fontSize: 25);
      const bottomSheetReleaseNotesTextStyle =
          TextStyle(color: Colors.purple, fontSize: 30);
      const bottomSheetBackgroundColor = Colors.teal;

      MaterialApp(
        scaffoldMessengerKey: rootScaffoldMessengerKey,
        home: UpgradeAnnouncer(
          scaffoldMessengerKey: rootScaffoldMessengerKey,
          backgroundColor: backgroundColor,
          infoIcon: infoIcon,
          infoIconColor: infoIconColor,
          downloadIcon: downloadIcon,
          downloadIconColor: downloadIconColor,
          titleTextStyle: titleTextStyle,
          bottomSheetTitleTextStyle: bottomSheetTitleTextStyle,
          bottomSheetReleaseNotesTextStyle: bottomSheetReleaseNotesTextStyle,
          bottomSheetBackgroundColor: bottomSheetBackgroundColor,
          child: Scaffold(
            body: const Placeholder(),
            appBar: AppBar(title: const Text('Upgrader test')),
          ),
        ),
      );
```

This new `UpgradeAnnouncer` widget is fully backed by a test.
