### PR TITLE
Support forcing an upgrade manually

### DIFF
--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -29,6 +29,7 @@ class UpgradeAlert extends StatefulWidget {
     this.showIgnore = true,
     this.showLater = true,
     this.showReleaseNotes = true,
+    this.forceUpgrade = false,
     this.cupertinoButtonTextStyle,
     this.dialogKey,
     this.navigatorKey,
@@ -67,6 +68,9 @@ class UpgradeAlert extends StatefulWidget {
 
   /// Hide or show release notes (default: true)
   final bool showReleaseNotes;
+
+  /// Force the upgrade dialog to display.
+  final bool forceUpgrade;
 
   /// The text style for the cupertino dialog buttons. Used only for
   /// [UpgradeDialogStyle.cupertino]. Optional.
@@ -132,7 +136,9 @@ class UpgradeAlertState extends State<UpgradeAlert> {
 
   /// Will show the alert dialog when it should be dispalyed.
   void checkVersion({required BuildContext context}) {
-    final shouldDisplay = widget.upgrader.shouldDisplayUpgrade();
+    final shouldDisplay = widget.upgrader.shouldDisplayUpgrade(
+      forceUpgrade: widget.forceUpgrade,
+    );
     if (widget.upgrader.state.debugLogging) {
       print('upgrader: shouldDisplayReleaseNotes: $shouldDisplayReleaseNotes');
     }

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -286,7 +286,7 @@ class Upgrader with WidgetsBindingObserver {
     return belowMinAppVersion() || versionInfo?.isCriticalUpdate == true;
   }
 
-  bool shouldDisplayUpgrade() {
+  bool shouldDisplayUpgrade({bool forceUpgrade = false}) {
     final isBlocked = blocked();
 
     if (state.debugLogging) {
@@ -298,6 +298,8 @@ class Upgrader with WidgetsBindingObserver {
 
     bool rv = true;
     if (state.debugDisplayAlways || (state.debugDisplayOnce && !_hasAlerted)) {
+      rv = true;
+    } else if (forceUpgrade) {
       rv = true;
     } else if (!isUpdateAvailable()) {
       rv = false;


### PR DESCRIPTION
In some cases I need to manually force an upgrade, so it will be nice to be able to do that by adding a new parameter (`forceUpgrade`). This should not cause breaking change as default value is false.

Please let me know if this makes sense. Thanks!