### PR TITLE
Feature Appcast buildNumber 

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -153,7 +153,9 @@ class Appcast {
         final tags = <String>[];
         String? newVersion;
         String? itemVersion;
+        String? itemShortVersion;
         String? enclosureVersion;
+        String? enclosureShortVersion;
 
         itemElement.children.forEach((XmlNode childNode) {
           if (childNode is XmlElement) {
@@ -162,6 +164,8 @@ class Appcast {
               title = childNode.innerText;
             } else if (name == AppcastConstants.ElementDescription) {
               itemDescription = childNode.innerText;
+            } else if (name == AppcastConstants.AttributeShortVersionString) {
+              itemShortVersion = childNode.innerText;
             } else if (name == AppcastConstants.ElementEnclosure) {
               childNode.attributes.forEach((XmlAttribute attribute) {
                 if (attribute.name.toString() ==
@@ -170,6 +174,9 @@ class Appcast {
                 } else if (attribute.name.toString() ==
                     AppcastConstants.AttributeOsType) {
                   osString = attribute.value;
+                } else if (attribute.name.toString() ==
+                    AppcastConstants.AttributeShortVersionString) {
+                  enclosureShortVersion = attribute.value;
                 } else if (attribute.name.toString() ==
                     AppcastConstants.AttributeURL) {
                   fileURL = attribute.value;
@@ -218,6 +225,7 @@ class Appcast {
           tags: tags,
           fileURL: fileURL,
           versionString: newVersion,
+          displayVersionString: itemShortVersion ?? enclosureShortVersion,
         );
         localItems.add(item);
       });

--- a/lib/src/upgrade_state.dart
+++ b/lib/src/upgrade_state.dart
@@ -19,6 +19,7 @@ class UpgraderState {
     this.debugDisplayAlways = false,
     this.debugDisplayOnce = false,
     this.debugLogging = false,
+    this.useBuildNumber = false,
     this.durationUntilAlertAgain = const Duration(days: 3),
     this.languageCodeOverride,
     this.messages,
@@ -46,6 +47,9 @@ class UpgraderState {
 
   /// Enable print statements for debugging.
   final bool debugLogging;
+
+  /// Use the build number instead of the version number.
+  final bool useBuildNumber;
 
   /// Duration until alerting user again.
   final Duration durationUntilAlertAgain;
@@ -83,6 +87,7 @@ class UpgraderState {
     bool? debugDisplayAlways,
     bool? debugDisplayOnce,
     bool? debugLogging,
+    bool? useBuildNumber,
     Duration? durationUntilAlertAgain,
     String? languageCodeOverride,
     UpgraderMessages? messages,
@@ -99,6 +104,7 @@ class UpgraderState {
       debugDisplayAlways: debugDisplayAlways ?? this.debugDisplayAlways,
       debugDisplayOnce: debugDisplayOnce ?? this.debugDisplayOnce,
       debugLogging: debugLogging ?? this.debugLogging,
+      useBuildNumber: useBuildNumber ?? this.useBuildNumber,
       durationUntilAlertAgain:
           durationUntilAlertAgain ?? this.durationUntilAlertAgain,
       languageCodeOverride: languageCodeOverride ?? this.languageCodeOverride,

--- a/lib/src/upgrade_store_controller.dart
+++ b/lib/src/upgrade_store_controller.dart
@@ -166,6 +166,7 @@ class UpgraderAppcastStore extends UpgraderStore {
       required String? language}) async {
     String? appStoreListingURL;
     Version? appStoreVersion;
+    Version? appStoreDisplayVersion;
     bool? isCriticalUpdate;
     String? releaseNotes;
 
@@ -185,13 +186,19 @@ class UpgraderAppcastStore extends UpgraderStore {
 
     final bestItem = localAppcast.bestItem();
     if (bestItem != null &&
-        bestItem.versionString != null &&
-        bestItem.versionString!.isNotEmpty) {
+        bestItem.versionString?.isNotEmpty == true &&
+        (!state.useBuildNumber || (bestItem.displayVersionString?.isNotEmpty == true))) {
       if (state.debugLogging) {
         print('upgrader: UpgraderAppcastStore best item version: '
             '${bestItem.versionString}');
         print('upgrader: UpgraderAppcastStore critical update item version: '
             '${criticalUpdateItem?.versionString}');
+      }
+      if (state.debugLogging && state.useBuildNumber) {
+        print('upgrader: UpgraderAppcastStore best item display version: '
+            '${bestItem.displayVersionString}');
+        print('upgrader: UpgraderAppcastStore critical update item display version: '
+            '${criticalUpdateItem?.displayVersionString}');
       }
 
       try {
@@ -217,6 +224,17 @@ class UpgraderAppcastStore extends UpgraderStore {
           }
         }
       }
+      if (state.useBuildNumber && bestItem.displayVersionString != null) {
+        try {
+          appStoreDisplayVersion = Version.parse(bestItem.displayVersionString!);
+        } catch (e) {
+          if (state.debugLogging) {
+            print(
+                'upgrader: UpgraderAppcastStore: best item display version could not be parsed: '
+                    '${bestItem.displayVersionString}');
+          }
+        }
+      }
 
       appStoreListingURL = bestItem.fileURL;
       releaseNotes = bestItem.itemDescription;
@@ -226,6 +244,7 @@ class UpgraderAppcastStore extends UpgraderStore {
       installedVersion: installedVersion,
       appStoreListingURL: appStoreListingURL,
       appStoreVersion: appStoreVersion,
+      appStoreDisplayVersion: appStoreDisplayVersion,
       isCriticalUpdate: isCriticalUpdate,
       releaseNotes: releaseNotes,
     );

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -392,7 +392,10 @@ class Upgrader with WidgetsBindingObserver {
     }
 
     try {
-      final installedVersion = Version.parse(state.packageInfo!.version);
+      final installedVersion = Version.parse(
+          state.useBuildNumber
+              ? state.packageInfo!.buildNumber
+              : state.packageInfo!.version);
 
       final available = versionInfo!.appStoreVersion! > installedVersion;
       _updateAvailable = available ? versionInfo?.appStoreVersion : null;

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -51,6 +51,7 @@ class Upgrader with WidgetsBindingObserver {
     bool debugDisplayAlways = false,
     bool debugDisplayOnce = false,
     bool debugLogging = false,
+    bool useBuildNumber = false,
     Duration durationUntilAlertAgain = const Duration(days: 3),
     String? languageCode,
     UpgraderMessages? messages,
@@ -66,6 +67,7 @@ class Upgrader with WidgetsBindingObserver {
           debugDisplayAlways: debugDisplayAlways,
           debugDisplayOnce: debugDisplayOnce,
           debugLogging: debugLogging,
+          useBuildNumber: useBuildNumber,
           durationUntilAlertAgain: durationUntilAlertAgain,
           languageCodeOverride: languageCode,
           messages: messages,
@@ -221,9 +223,16 @@ class Upgrader with WidgetsBindingObserver {
     }
 
     // Determine the installed version of this app.
+    // If the build number is to be used and Appcast Store is used, then use the build number.
     late Version installedVersion;
     try {
-      installedVersion = Version.parse(state.packageInfo!.version);
+      if (state.useBuildNumber
+          && storeController.getUpgraderStore(state.upgraderOS)
+          is UpgraderAppcastStore) {
+        installedVersion = Version.parse(state.packageInfo!.buildNumber);
+      } else {
+        installedVersion = Version.parse(state.packageInfo!.version);
+      }
     } catch (e) {
       if (state.debugLogging) {
         print('upgrader: installedVersion exception: $e');

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -152,6 +152,7 @@ class Upgrader with WidgetsBindingObserver {
         print('upgrader: packageInfo packageName: ${packageInfo.packageName}');
         print('upgrader: packageInfo appName: ${packageInfo.appName}');
         print('upgrader: packageInfo version: ${packageInfo.version}');
+        print('upgrader: packageInfo buildNumber: ${packageInfo.buildNumber}');
       }
 
       await updateVersionInfo();
@@ -230,6 +231,9 @@ class Upgrader with WidgetsBindingObserver {
           && storeController.getUpgraderStore(state.upgraderOS)
           is UpgraderAppcastStore) {
         installedVersion = Version.parse(state.packageInfo!.buildNumber);
+        if (state.debugLogging) {
+          print('upgrader: using build number ${state.packageInfo!.buildNumber} as version: ${state.packageInfo!.version}+b${state.packageInfo!.buildNumber}');
+        }
       } else {
         installedVersion = Version.parse(state.packageInfo!.version);
       }
@@ -372,7 +376,13 @@ class Upgrader with WidgetsBindingObserver {
 
   bool isUpdateAvailable() {
     if (state.debugLogging) {
-      print('upgrader: installedVersion: ${state.packageInfo?.version}');
+      if (state.useBuildNumber
+          && storeController.getUpgraderStore(state.upgraderOS)
+          is UpgraderAppcastStore) {
+        print('upgrader: installedVersion: ${state.packageInfo?.version}+b${state.packageInfo?.buildNumber}');
+      } else {
+        print('upgrader: installedVersion: ${state.packageInfo?.version}');
+      }
       print('upgrader: minAppVersion: ${state.minAppVersion}');
     }
     if (versionInfo?.appStoreVersion == null ||

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -554,9 +554,13 @@ extension UpgraderExt on Upgrader {
       state.versionInfo?.appStoreListingURL;
 
   String? get currentAppStoreVersion =>
-      state.versionInfo?.appStoreVersion?.toString();
+      state.useBuildNumber
+          ? state.versionInfo?.appStoreDisplayVersion?.toString()
+          : state.versionInfo?.appStoreVersion?.toString();
 
-  String? get currentInstalledVersion => state.packageInfo?.version;
+  String? get currentInstalledVersion => state.useBuildNumber
+      ? "${state.packageInfo?.version}+b${state.packageInfo?.buildNumber}"
+      : state.packageInfo?.version;
 
   String? get releaseNotes => state.versionInfo?.releaseNotes;
 

--- a/lib/src/upgrader_version_info.dart
+++ b/lib/src/upgrader_version_info.dart
@@ -5,6 +5,7 @@ import 'package:version/version.dart';
 class UpgraderVersionInfo {
   final String? appStoreListingURL;
   final Version? appStoreVersion;
+  final Version? appStoreDisplayVersion;
   final Version? installedVersion;
   final bool? isCriticalUpdate;
   final Version? minAppVersion;
@@ -13,6 +14,7 @@ class UpgraderVersionInfo {
   UpgraderVersionInfo({
     this.appStoreListingURL,
     this.appStoreVersion,
+    this.appStoreDisplayVersion,
     this.installedVersion,
     this.isCriticalUpdate,
     this.minAppVersion,
@@ -23,6 +25,7 @@ class UpgraderVersionInfo {
   String toString() {
     return 'appStoreListingURL: $appStoreListingURL, '
         'appStoreVersion: $appStoreVersion, '
+        'appStoreDisplayVersion: $appStoreDisplayVersion, '
         'installedVersion: $installedVersion, '
         'isCriticalUpdate: $isCriticalUpdate, '
         'minAppVersion: $minAppVersion, '

--- a/test/upgrader_version_info_test.dart
+++ b/test/upgrader_version_info_test.dart
@@ -49,6 +49,7 @@ void main() {
     UpgraderVersionInfo versionInfo = UpgraderVersionInfo(
       appStoreListingURL: null,
       appStoreVersion: null,
+      appStoreDisplayVersion: null,
       installedVersion: null,
       isCriticalUpdate: null,
       minAppVersion: null,
@@ -60,7 +61,7 @@ void main() {
     expect(
         result,
         equals(
-            'appStoreListingURL: null, appStoreVersion: null, installedVersion: null, isCriticalUpdate: null, minAppVersion: null, releaseNotes: null'));
+            'appStoreListingURL: null, appStoreVersion: null, appStoreDisplayVersion: null, installedVersion: null, isCriticalUpdate: null, minAppVersion: null, releaseNotes: null'));
   });
   test('create_instance_with_one_parameter_null', () {
     Version appStoreVersion = Version.parse('1.0.0');


### PR DESCRIPTION
This pull request implements the Appcast "displayVersion" that was left unimplemented, this tag is, under-the-hood, `sparkle:shortVersionString`, and when this tag exists, it means that the `sparkle:version` is actually the buildNumber. Adding the flag `useBuildNumber` in the Upgrader widget, and ensuring that the `AppStore` is `UpgraderAppcastStore`, we can allow internal testers to be notified about new builds that share the same common version.


The buildNumber feature is not enabled if the AppStore is not AppcastStore, since we rely on the official "published" app in PlayStore / iOS AppStore by default.

This pull request surely needs some refining in terms of more assertions and adding tests, but seems working fine.

Test appcast.xml gist [here](https://gist.github.com/renzullomichele/b7d2408c9d2b9397305bd553370b3eb8)