### PR TITLE
Description Handle Blocks Updated

### DIFF
--- a/lib/src/itunes_search_api.dart
+++ b/lib/src/itunes_search_api.dart
@@ -193,7 +193,7 @@ extension ITunesResults on ITunesSearchAPI {
   String? description(Map response) {
     String? value;
     try {
-      value = response['results'][0]['description'];
+      value = response['results'][0]['releaseNotes'];
     } catch (e) {
       if (debugLogging) {
         print('upgrader.ITunesResults.description: $e');

--- a/lib/src/play_store_search_api.dart
+++ b/lib/src/play_store_search_api.dart
@@ -117,7 +117,7 @@ extension PlayStoreResults on PlayStoreSearchAPI {
   /// Return field description from Redesigned Play Store results.
   String? redesignedDescription(Document response) {
     try {
-      final sectionElements = response.getElementsByClassName('bARER');
+      final sectionElements = response.querySelectorAll('[itemprop="description"]');
       final descriptionElement = sectionElements.last;
       final description = descriptionElement.text;
       return description;


### PR DESCRIPTION
On the iOS side, when the description key in the JSON response passed to the model does not contain the [:mav] text, it was replaced with releaseNotes. On the Android side, since the ClassName changed, it was captured using querySelector and assigned to the minVersion variable.