### PR TITLE
fix: show `UpgradeAlert` above subsequent navigator pushes

### DIFF
--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -96,6 +96,8 @@ class UpgradeAlert extends StatefulWidget {
 class UpgradeAlertState extends State<UpgradeAlert> {
   /// Is the alert dialog being displayed right now?
   bool displayed = false;
+  final GlobalKey<NavigatorState> _dialogNavigatorKey =
+      GlobalKey<NavigatorState>();
 
   @override
   void initState() {
@@ -132,7 +134,30 @@ class UpgradeAlertState extends State<UpgradeAlert> {
             }
           }
         }
-        return widget.child ?? const SizedBox.shrink();
+        return Stack(
+          children: [
+            widget.child ?? const SizedBox.shrink(),
+            Positioned.fill(
+              child: Offstage(
+                offstage: !displayed,
+                child: HeroControllerScope.none(
+                  child: Navigator(
+                    key: _dialogNavigatorKey,
+                    onGenerateRoute: (settings) => PageRouteBuilder<void>(
+                      settings: settings,
+                      opaque: false,
+                      barrierColor: Colors.transparent,
+                      pageBuilder: (context, animation, secondaryAnimation) =>
+                          const SizedBox.shrink(),
+                      transitionDuration: Duration.zero,
+                      reverseTransitionDuration: Duration.zero,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        );
       },
     );
   }
@@ -212,7 +237,7 @@ class UpgradeAlertState extends State<UpgradeAlert> {
 
   void popNavigator(BuildContext context) {
     Navigator.of(context).pop();
-    displayed = false;
+    if (mounted) setState(() {});
   }
 
   bool get shouldDisplayReleaseNotes =>
@@ -248,6 +273,7 @@ class UpgradeAlertState extends State<UpgradeAlert> {
     // Detect if CupertinoApp is in the widget tree
     final isCupertinoApp =
         context.findAncestorWidgetOfExactType<CupertinoApp>() != null;
+    final dialogContext = _dialogNavigatorKey.currentContext ?? context;
 
     dialogBuilder(BuildContext context) => PopScope(
           canPop: onCanPop(),
@@ -270,13 +296,15 @@ class UpgradeAlertState extends State<UpgradeAlert> {
     if (isCupertinoApp) {
       showCupertinoDialog(
         barrierDismissible: barrierDismissible,
-        context: context,
+        context: dialogContext,
+        useRootNavigator: false,
         builder: dialogBuilder,
       );
     } else {
       showDialog(
         barrierDismissible: barrierDismissible,
-        context: context,
+        context: dialogContext,
+        useRootNavigator: false,
         builder: dialogBuilder,
       );
     }

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -237,7 +237,7 @@ class UpgradeAlertState extends State<UpgradeAlert> {
 
   void popNavigator(BuildContext context) {
     Navigator.of(context).pop();
-    if (mounted) setState(() {});
+    displayed = false;
   }
 
   bool get shouldDisplayReleaseNotes =>

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -236,8 +236,10 @@ class UpgradeAlertState extends State<UpgradeAlert> {
   }
 
   void popNavigator(BuildContext context) {
+    setState(() {
+      displayed = false;
+    });
     Navigator.of(context).pop();
-    displayed = false;
   }
 
   bool get shouldDisplayReleaseNotes =>

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -134,24 +134,25 @@ class UpgradeAlertState extends State<UpgradeAlert> {
             }
           }
         }
+        final child = widget.child ?? const SizedBox.shrink();
+        if (widget.child == null || !displayed) {
+          return child;
+        }
+
         return Stack(
           children: [
-            widget.child ?? const SizedBox.shrink(),
+            child,
             Positioned.fill(
-              child: Offstage(
-                offstage: !displayed,
-                child: HeroControllerScope.none(
-                  child: Navigator(
-                    key: _dialogNavigatorKey,
-                    onGenerateRoute: (settings) => PageRouteBuilder<void>(
-                      settings: settings,
-                      opaque: false,
-                      barrierColor: Colors.transparent,
-                      pageBuilder: (context, animation, secondaryAnimation) =>
-                          const SizedBox.shrink(),
-                      transitionDuration: Duration.zero,
-                      reverseTransitionDuration: Duration.zero,
-                    ),
+              child: HeroControllerScope.none(
+                child: Navigator(
+                  key: _dialogNavigatorKey,
+                  onGenerateRoute: (settings) => PageRouteBuilder<void>(
+                    settings: settings,
+                    opaque: false,
+                    pageBuilder: (context, animation, secondaryAnimation) =>
+                        const SizedBox.shrink(),
+                    transitionDuration: Duration.zero,
+                    reverseTransitionDuration: Duration.zero,
                   ),
                 ),
               ),

--- a/test/upgrade_alert_test.dart
+++ b/test/upgrade_alert_test.dart
@@ -74,6 +74,10 @@ void main() {
   testWidgets(
     'test UpgradeAlert stays above a later pushed route',
     (WidgetTester tester) async {
+      final delayDuration = 2;
+      final laterTitle =
+          UpgraderMessages().message(UpgraderMessage.buttonTitleLater)!;
+
       var laterTapped = false;
       final upgrader = Upgrader(
         debugDisplayAlways: true,
@@ -96,20 +100,28 @@ void main() {
               laterTapped = true;
               return true;
             },
-            child: child ?? const SizedBox.shrink(),
+            child: child,
           ),
-          home: const _DelayedPushScreen(),
+          home: _SplashScreen(
+            Duration(seconds: delayDuration),
+          ),
         ),
       );
+      await tester.pump(Duration(seconds: delayDuration - 1));
       await tester.pumpAndSettle();
 
-      expect(find.text('home'), findsOneWidget);
+      expect(find.byType(_SplashScreen), findsOneWidget);
+      expect(find.byType(_HomeScreen), findsNothing);
+      expect(find.text(laterTitle), findsOneWidget,
+          reason: 'UpgradeAlert should be visible before the route is pushed');
 
-      await tester.tap(
-        find.text(
-          UpgraderMessages().message(UpgraderMessage.buttonTitleLater)!,
-        ),
-      );
+      await tester.pump(Duration(seconds: delayDuration));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(_HomeScreen), findsOneWidget);
+      expect(find.byType(_SplashScreen), findsNothing);
+
+      await tester.tap(find.text(laterTitle));
       await tester.pumpAndSettle();
 
       expect(laterTapped, true);
@@ -117,28 +129,22 @@ void main() {
   );
 }
 
-class _DelayedPushScreen extends StatefulWidget {
-  const _DelayedPushScreen();
+class _SplashScreen extends StatefulWidget {
+  final Duration delay;
+  const _SplashScreen(this.delay);
 
   @override
-  State<_DelayedPushScreen> createState() => _DelayedPushScreenState();
+  State<_SplashScreen> createState() => _SplashScreenState();
 }
 
-class _DelayedPushScreenState extends State<_DelayedPushScreen> {
+class _SplashScreenState extends State<_SplashScreen> {
   @override
   void initState() {
     super.initState();
-    Future.delayed(const Duration(milliseconds: 100), () {
-      if (!mounted) {
-        return;
-      }
+    Future.delayed(widget.delay, () {
       Navigator.of(context).push(
         MaterialPageRoute<void>(
-          builder: (context) => const Scaffold(
-            body: Center(
-              child: Text('home'),
-            ),
-          ),
+          builder: (context) => const _HomeScreen(),
         ),
       );
     });
@@ -149,6 +155,19 @@ class _DelayedPushScreenState extends State<_DelayedPushScreen> {
     return const Scaffold(
       body: Center(
         child: Text('splash'),
+      ),
+    );
+  }
+}
+
+class _HomeScreen extends StatelessWidget {
+  const _HomeScreen();
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('home'),
       ),
     );
   }

--- a/test/upgrade_alert_test.dart
+++ b/test/upgrade_alert_test.dart
@@ -1,5 +1,6 @@
 // Copyright (c) 2024 Larry Aasen. All rights reserved.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:upgrader/upgrader.dart';
@@ -69,4 +70,86 @@ void main() {
       );
     },
   );
+
+  testWidgets(
+    'test UpgradeAlert stays above a later pushed route',
+    (WidgetTester tester) async {
+      var laterTapped = false;
+      final upgrader = Upgrader(
+        debugDisplayAlways: true,
+        upgraderOS: MockUpgraderOS(ios: true),
+      )
+        ..installPackageInfo(
+          packageInfo: PackageInfo(
+              appName: 'Upgrader',
+              packageName: 'com.larryaasen.upgrader',
+              version: '0.9.9',
+              buildNumber: '400'),
+        )
+        ..initialize();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          builder: (context, child) => UpgradeAlert(
+            upgrader: upgrader,
+            onLater: () {
+              laterTapped = true;
+              return true;
+            },
+            child: child ?? const SizedBox.shrink(),
+          ),
+          home: const _DelayedPushScreen(),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('home'), findsOneWidget);
+
+      await tester.tap(
+        find.text(
+          UpgraderMessages().message(UpgraderMessage.buttonTitleLater)!,
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(laterTapped, true);
+    },
+  );
+}
+
+class _DelayedPushScreen extends StatefulWidget {
+  const _DelayedPushScreen();
+
+  @override
+  State<_DelayedPushScreen> createState() => _DelayedPushScreenState();
+}
+
+class _DelayedPushScreenState extends State<_DelayedPushScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Future.delayed(const Duration(milliseconds: 100), () {
+      if (!mounted) {
+        return;
+      }
+      Navigator.of(context).push(
+        MaterialPageRoute<void>(
+          builder: (context) => const Scaffold(
+            body: Center(
+              child: Text('home'),
+            ),
+          ),
+        ),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      body: Center(
+        child: Text('splash'),
+      ),
+    );
+  }
 }

--- a/test/upgrade_alert_test.dart
+++ b/test/upgrade_alert_test.dart
@@ -94,6 +94,7 @@ void main() {
 
       await tester.pumpWidget(
         MaterialApp(
+          theme: ThemeData(splashFactory: NoSplash.splashFactory),
           builder: (context, child) => UpgradeAlert(
             upgrader: upgrader,
             onLater: () {


### PR DESCRIPTION
Resolves #540

| Before  | After |
| ------------- |:-------------:|
|   <video src=https://github.com/user-attachments/assets/efc49bd9-ab31-46c4-be3e-d34421a739c9>  | <video src=https://github.com/user-attachments/assets/cdc38a3e-2723-493b-a901-46e48772b929>     |







