### PR TITLE
Add minimumUpdateVersion parsing from Appcast XML

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -30,11 +30,15 @@ class Appcast {
   /// The operating system version.
   final Version osVersion;
 
+  /// The current app version, used to check [AppcastItem.minimumUpdateVersion].
+  final Version? currentAppVersion;
+
   Appcast(
       {http.Client? client,
       this.clientHeaders,
       UpgraderOS? upgraderOS,
-      required this.osVersion})
+      required this.osVersion,
+      this.currentAppVersion})
       : client = client ?? http.Client(),
         upgraderOS = upgraderOS ?? UpgraderOS();
 
@@ -50,7 +54,9 @@ class Appcast {
     AppcastItem? bestItem;
     items!.forEach((AppcastItem item) {
       if (item.hostSupportsItem(
-              osVersion: osVersion, currentPlatform: upgraderOS.current) &&
+              osVersion: osVersion,
+              currentPlatform: upgraderOS.current,
+              currentAppVersion: currentAppVersion) &&
           item.isCriticalUpdate) {
         if (bestItem == null) {
           bestItem = item;
@@ -80,7 +86,9 @@ class Appcast {
     AppcastItem? bestItem;
     items!.forEach((AppcastItem item) {
       if (item.hostSupportsItem(
-          osVersion: osVersion, currentPlatform: upgraderOS.current)) {
+          osVersion: osVersion,
+          currentPlatform: upgraderOS.current,
+          currentAppVersion: currentAppVersion)) {
         if (bestItem == null) {
           bestItem = item;
         } else {
@@ -142,6 +150,7 @@ class Appcast {
         String? fileURL;
         String? maximumSystemVersion;
         String? minimumSystemVersion;
+        String? minimumUpdateVersion;
         String? osString;
         String? releaseNotesLink;
         final tags = <String>[];
@@ -173,6 +182,8 @@ class Appcast {
               maximumSystemVersion = childNode.innerText;
             } else if (name == AppcastConstants.ElementMinimumSystemVersion) {
               minimumSystemVersion = childNode.innerText;
+            } else if (name == AppcastConstants.ElementMinimumUpdateVersion) {
+              minimumUpdateVersion = childNode.innerText;
             } else if (name == AppcastConstants.ElementPubDate) {
               dateString = childNode.innerText;
             } else if (name == AppcastConstants.ElementReleaseNotesLink) {
@@ -207,6 +218,7 @@ class Appcast {
           dateString: dateString,
           maximumSystemVersion: maximumSystemVersion,
           minimumSystemVersion: minimumSystemVersion,
+          minimumUpdateVersion: minimumUpdateVersion,
           osString: osString,
           releaseNotesURL: releaseNotesLink,
           tags: tags,
@@ -232,6 +244,7 @@ class AppcastItem {
   final String? releaseNotesURL;
   final String? minimumSystemVersion;
   final String? maximumSystemVersion;
+  final String? minimumUpdateVersion;
   final String? fileURL;
   final int? contentLength;
   final String? versionString;
@@ -247,6 +260,7 @@ class AppcastItem {
     this.releaseNotesURL,
     this.minimumSystemVersion,
     this.maximumSystemVersion,
+    this.minimumUpdateVersion,
     this.fileURL,
     this.contentLength,
     this.versionString,
@@ -263,8 +277,11 @@ class AppcastItem {
       : tags!.contains(AppcastConstants.ElementCriticalUpdate);
 
   /// Does the host support this item? If so is [osVersion] supported?
+  /// Optionally pass [currentAppVersion] to check [minimumUpdateVersion].
   bool hostSupportsItem(
-      {required Version osVersion, required String currentPlatform}) {
+      {required Version osVersion,
+      required String currentPlatform,
+      Version? currentAppVersion}) {
     assert(currentPlatform.isNotEmpty);
     bool supported = true;
     if (osString != null && osString!.isNotEmpty) {
@@ -294,6 +311,16 @@ class AppcastItem {
           print('upgrader: hostSupportsItem invalid minimumSystemVersion: $e');
         }
       }
+      if (supported && minimumUpdateVersion != null && currentAppVersion != null) {
+        try {
+          final minUpdateVersion = Version.parse(minimumUpdateVersion!);
+          if (currentAppVersion < minUpdateVersion) {
+            supported = false;
+          }
+        } on Exception catch (e) {
+          print('upgrader: hostSupportsItem invalid minimumUpdateVersion: $e');
+        }
+      }
     }
     return supported;
   }
@@ -316,6 +343,8 @@ class AppcastConstants {
       'sparkle:minimumSystemVersion';
   static const String ElementMaximumSystemVersion =
       'sparkle:maximumSystemVersion';
+  static const String ElementMinimumUpdateVersion =
+      'sparkle:minimumUpdateVersion';
   static const String ElementReleaseNotesLink = 'sparkle:releaseNotesLink';
   static const String ElementTags = 'sparkle:tags';
 

--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -183,7 +183,8 @@ class Appcast {
             } else if (name == AppcastConstants.ElementMinimumSystemVersion) {
               minimumSystemVersion = childNode.innerText;
             } else if (name == AppcastConstants.ElementMinimumUpdateVersion) {
-              minimumUpdateVersion = childNode.innerText;
+              final text = childNode.innerText.trim();
+              minimumUpdateVersion = text.isEmpty ? null : text;
             } else if (name == AppcastConstants.ElementPubDate) {
               dateString = childNode.innerText;
             } else if (name == AppcastConstants.ElementReleaseNotesLink) {

--- a/lib/src/upgrade_store_controller.dart
+++ b/lib/src/upgrade_store_controller.dart
@@ -192,7 +192,8 @@ class UpgraderAppcastStore extends UpgraderStore {
             client: state.client,
             clientHeaders: state.clientHeaders,
             upgraderOS: state.upgraderOS,
-            osVersion: parsedOsVersion);
+            osVersion: parsedOsVersion,
+            currentAppVersion: installedVersion);
     await localAppcast.parseAppcastItemsFromUri(appcastURL);
     if (state.debugLogging) {
       var count = localAppcast.items == null ? 0 : localAppcast.items!.length;

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -226,6 +226,50 @@ void main() {
     );
   });
 
+  test('minimumUpdateVersion trims whitespace from XML', () async {
+    final appcast = TestAppcast(
+      upgraderOS: MockUpgraderOS(android: true),
+      osVersion: Version(0, 0, 0),
+      currentAppVersion: Version(1, 9, 0),
+    );
+    const xml = '''<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <sparkle:version>6.0.0</sparkle:version>
+      <sparkle:minimumUpdateVersion>
+        1.9.0
+      </sparkle:minimumUpdateVersion>
+    </item>
+  </channel>
+</rss>''';
+    await appcast.parseAppcastItems(xml);
+    final best = appcast.bestItem();
+    expect(best, isNotNull);
+    expect(best!.minimumUpdateVersion, equals('1.9.0'));
+    expect(best.versionString, equals('6.0.0'));
+  });
+
+  test('minimumUpdateVersion empty whitespace get treated as null', () async {
+    final appcast = TestAppcast(
+      upgraderOS: MockUpgraderOS(android: true),
+      osVersion: Version(0, 0, 0),
+    );
+    const xml = '''<?xml version="1.0" encoding="utf-8"?>
+<rss version="2.0" xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+  <channel>
+    <item>
+      <sparkle:version>6.0.0</sparkle:version>
+      <sparkle:minimumUpdateVersion>   </sparkle:minimumUpdateVersion>
+    </item>
+  </channel>
+</rss>''';
+    await appcast.parseAppcastItems(xml);
+    final best = appcast.bestItem();
+    expect(best, isNotNull);
+    expect(best!.minimumUpdateVersion, isNull);
+  });
+
   test('Appcast multi multi enclosure', () async {
     final appcast = TestAppcast(
         upgraderOS: MockUpgraderOS(android: true), osVersion: Version(0, 0, 0));

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -250,7 +250,7 @@ void main() {
     expect(best.versionString, equals('6.0.0'));
   });
 
-  test('minimumUpdateVersion empty whitespace get treated as null', () async {
+  test('minimumUpdateVersion empty whitespace is treated as null', () async {
     final appcast = TestAppcast(
       upgraderOS: MockUpgraderOS(android: true),
       osVersion: Version(0, 0, 0),

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -174,6 +174,58 @@ void main() {
     expect(bestItem, isNotNull);
     expect(bestItem.versionString, equals('2.7.2'));
   });
+  test('bestItem respects minimumUpdateVersion', () async {
+    final appcast19 = TestAppcast(
+      upgraderOS: MockUpgraderOS(android: true),
+      osVersion: Version(0, 0, 0),
+      currentAppVersion: Version(1, 9, 0),
+    );
+    await appcast19.parseAppcastItemsFromFile(await getTestFile());
+    expect(appcast19.bestItem()?.versionString, equals('6.0'));
+
+    final appcast18 = TestAppcast(
+      upgraderOS: MockUpgraderOS(android: true),
+      osVersion: Version(0, 0, 0),
+      currentAppVersion: Version(1, 8, 0),
+    );
+    await appcast18.parseAppcastItemsFromFile(await getTestFile());
+    expect(appcast18.bestItem()?.versionString, equals('5.0'));
+  });
+
+  test('minimumUpdateVersion allows 1.9 but blocks 1.8', () {
+    final item = AppcastItem(
+      versionString: '6.0',
+      minimumUpdateVersion: '1.9',
+    );
+
+    expect(
+      item.hostSupportsItem(
+        osVersion: Version(0, 0, 0),
+        currentPlatform: 'android',
+        currentAppVersion: Version(1, 9, 0),
+      ),
+      equals(true),
+    );
+
+    expect(
+      item.hostSupportsItem(
+        osVersion: Version(0, 0, 0),
+        currentPlatform: 'android',
+        currentAppVersion: Version(1, 8, 0),
+      ),
+      equals(false),
+    );
+
+    // No currentAppVersion provided — minimumUpdateVersion check is skipped
+    expect(
+      item.hostSupportsItem(
+        osVersion: Version(0, 0, 0),
+        currentPlatform: 'android',
+      ),
+      equals(true),
+    );
+  });
+
   test('Appcast multi multi enclosure', () async {
     final appcast = TestAppcast(
         upgraderOS: MockUpgraderOS(android: true), osVersion: Version(0, 0, 0));
@@ -187,7 +239,7 @@ void main() {
 }
 
 void validateItems(List<AppcastItem> items, Appcast appcast) {
-  expect(items.length, equals(4));
+  expect(items.length, equals(5));
 
   expect(items[0].title, equals('Version 2.0'));
   expect(items[0].itemDescription, equals('desc Версия'));
@@ -245,6 +297,7 @@ void validateItems(List<AppcastItem> items, Appcast appcast) {
   expect(items[3].isCriticalUpdate, equals(false));
   expect(items[3].maximumSystemVersion, equals('2.0.0'));
   expect(items[3].minimumSystemVersion, isNull);
+  expect(items[3].minimumUpdateVersion, isNull);
   expect(items[3].versionString, equals('5.0'));
   expect(
       items[3].hostSupportsItem(
@@ -256,9 +309,20 @@ void validateItems(List<AppcastItem> items, Appcast appcast) {
       equals(false));
   expect(items[3].osString, isNull);
 
+  expect(items[4].title, equals('Version 6.0'));
+  expect(items[4].itemDescription, isNull);
+  expect(items[4].dateString, isNull);
+  expect(items[4].fileURL, isNull);
+  expect(items[4].isCriticalUpdate, equals(false));
+  expect(items[4].maximumSystemVersion, isNull);
+  expect(items[4].minimumSystemVersion, isNull);
+  expect(items[4].minimumUpdateVersion, equals('1.9'));
+  expect(items[4].versionString, equals('6.0'));
+  expect(items[4].osString, isNull);
+
   final bestItem = appcast.bestItem()!;
   expect(bestItem, isNotNull);
-  expect(bestItem.versionString, equals('5.0'));
+  expect(bestItem.versionString, equals('6.0'));
   expect(
       bestItem.hostSupportsItem(
           osVersion: Version(0, 0, 1), currentPlatform: 'android'),
@@ -293,7 +357,7 @@ http.Client setupMockClient({String filePath = 'test/testappcast.xml'}) {
 }
 
 class TestAppcast extends Appcast {
-  TestAppcast({super.client, super.upgraderOS, required super.osVersion});
+  TestAppcast({super.client, super.upgraderOS, required super.osVersion, super.currentAppVersion});
 
   /// Load the Appcast from [file].
   Future<List<AppcastItem>?> parseAppcastItemsFromFile(File file) async {

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -181,7 +181,7 @@ void main() {
       currentAppVersion: Version(1, 9, 0),
     );
     await appcast19.parseAppcastItemsFromFile(await getTestFile());
-    expect(appcast19.bestItem()?.versionString, equals('6.0'));
+    expect(appcast19.bestItem()?.versionString, equals('6.0.0'));
 
     final appcast18 = TestAppcast(
       upgraderOS: MockUpgraderOS(android: true),
@@ -194,8 +194,8 @@ void main() {
 
   test('minimumUpdateVersion allows 1.9 but blocks 1.8', () {
     final item = AppcastItem(
-      versionString: '6.0',
-      minimumUpdateVersion: '1.9',
+      versionString: '6.0.0',
+      minimumUpdateVersion: '1.9.0',
     );
 
     expect(
@@ -316,13 +316,13 @@ void validateItems(List<AppcastItem> items, Appcast appcast) {
   expect(items[4].isCriticalUpdate, equals(false));
   expect(items[4].maximumSystemVersion, isNull);
   expect(items[4].minimumSystemVersion, isNull);
-  expect(items[4].minimumUpdateVersion, equals('1.9'));
-  expect(items[4].versionString, equals('6.0'));
+  expect(items[4].minimumUpdateVersion, equals('1.9.0'));
+  expect(items[4].versionString, equals('6.0.0'));
   expect(items[4].osString, isNull);
 
   final bestItem = appcast.bestItem()!;
   expect(bestItem, isNotNull);
-  expect(bestItem.versionString, equals('6.0'));
+  expect(bestItem.versionString, equals('6.0.0'));
   expect(
       bestItem.hostSupportsItem(
           osVersion: Version(0, 0, 1), currentPlatform: 'android'),

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -192,7 +192,7 @@ void main() {
     expect(appcast18.bestItem()?.versionString, equals('5.0'));
   });
 
-  test('minimumUpdateVersion allows 1.9 but blocks 1.8', () {
+  test('minimumUpdateVersion allows 1.9.0 but blocks 1.8.0', () {
     final item = AppcastItem(
       versionString: '6.0.0',
       minimumUpdateVersion: '1.9.0',

--- a/test/testappcast.xml
+++ b/test/testappcast.xml
@@ -44,5 +44,11 @@
         <sparkle:version>5.0</sparkle:version>
         <sparkle:maximumSystemVersion>2.0.0</sparkle:maximumSystemVersion>
     </item>
+    <!-- A release testing minimumUpdateVersion -->
+    <item>
+        <title>Version 6.0</title>
+        <sparkle:version>6.0</sparkle:version>
+        <sparkle:minimumUpdateVersion>1.9</sparkle:minimumUpdateVersion>
+    </item>
   </channel>
 </rss>

--- a/test/testappcast.xml
+++ b/test/testappcast.xml
@@ -47,8 +47,8 @@
     <!-- A release testing minimumUpdateVersion -->
     <item>
         <title>Version 6.0</title>
-        <sparkle:version>6.0</sparkle:version>
-        <sparkle:minimumUpdateVersion>1.9</sparkle:minimumUpdateVersion>
+        <sparkle:version>6.0.0</sparkle:version>
+        <sparkle:minimumUpdateVersion>1.9.0</sparkle:minimumUpdateVersion>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
# Add support for `sparkle:minimumUpdateVersion` in Appcast parsing


### 📌 Summary

This PR adds parsing and enforcement of the `sparkle:minimumUpdateVersion` XML tag from Appcast feeds — a *Sparkle-standard* element that wasn't used by the upgrader package.

This enables enforcing a minimum eligible app version before an update is offered to the user.

While `minAppVersion` could technically serve the same purpose, it required either embedding a version tag inside the app store description text, or hard-coding it directly in the app — both of which **scattered control away from the release definition**. By parsing `sparkle:minimumUpdateVersion` directly from the **Appcast** feed, this logic is now centralized where it belongs: alongside the release itself, in the same file that defines it — and it works across any platform that uses an Appcast-based update feed.

-----------------------------

### 🚀 What Changed
- 📄 `lib/src/appcast.dart`
  - Added `minimumUpdateVersion` field to `AppcastItem`
  - Parsed from `sparkle:minimumUpdateVersion` in the XML feed

- Added `ElementMinimumUpdateVersion` constant to `AppcastConstants`

- Extended `hostSupportsItem()` to accept optional `currentAppVersion`
  - If `minimumUpdateVersion` exists **and** `currentAppVersion < minimumUpdateVersion`
  - → returns `false`

- Backwards compatible behavior
  - If `currentAppVersion` is **not provided**, check is skipped

- Added `currentAppVersion` field to `Appcast`
  - Passed to `hostSupportsItem()` when selecting:
    - Regular updates
    - Critical updates

---

### 📄 `lib/src/upgrade_store_controller.dart`

- Passes `installedVersion` as `currentAppVersion`
- Enables **end-to-end minimum version filtering**

---

### 🧪 `test/testappcast.xml`

- Added new `<item>`
  - `Version 6.0`
  - `sparkle:minimumUpdateVersion = 1.9.0`
- Used as fixture for new tests

---

### 🧪 `test/appcast_test.dart`

#### Added Unit Test

**`minimumUpdateVersion allows 1.9.0 but blocks 1.8.0`**

Tests:

- ✅ Eligible version — user on 1.9 meets the minimum, update is offered
- ❌ Blocked version — user on 1.8 falls below the minimum, update is withheld
- ⚙️ Unknown version — no currentAppVersion provided, check is skipped and update is offered

- When `minimumUpdateVersion` is not present in the item, check is skipped and update is offered to all users
---

#### Added Integration Test

**`bestItem respects minimumUpdateVersion`**

Verifies:

- App on `v1.9.0` → receives **Version 6.0**
- App on `v1.8.0` → falls back to **Version 5.0**

---

#### Updated

- Updated `validateItems`
- Added assertions for **Version 6.0**
- Includes `minimumUpdateVersion`

---
### Example of XML tag in Appcast  

```
<item>
  <title>Version 6.0</title>
  <sparkle:minimumUpdateVersion>1.9.0</sparkle:minimumUpdateVersion>
</item>
```

For the full list of supported Appcast tags, see the [Sparkle documentation](https://sparkle-project.org/documentation/publishing/)