### PR TITLE
loosen constraint on package_info_plus to support v10, remove unused go_router dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,6 +42,5 @@ dev_dependencies:
   # From Dart Team: Mock library for Dart inspired by Mockito.
   mockito: ^5.4.3
   flutter_lints:
-  go_router: ^14.2.7
 
 flutter:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   os_detect: ^2.0.1
 
   # From Flutter Community: Provides an API for querying information about an application package.
-  package_info_plus: '>=4.0.1 <10.0.0'
+  package_info_plus: '>=4.0.1 <11.0.0'
 
   # From Flutter Team: Wraps NSUserDefaults (on iOS) and SharedPreferences (on Android).
   shared_preferences: '>=2.1.1 <3.0.0'


### PR DESCRIPTION
- loosen constraint on package_info_plus to support v10
- remove unused go_router dev dependency
- fix https://github.com/larryaasen/upgrader/issues/545