### PR TITLE
Add edSignature parsing from Appcast XML and make bestItem accessible

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -148,6 +148,7 @@ class Appcast {
         String? itemDescription;
         String? dateString;
         String? fileURL;
+        String? edSignature;
         String? maximumSystemVersion;
         String? minimumSystemVersion;
         String? minimumUpdateVersion;
@@ -176,6 +177,9 @@ class Appcast {
                 } else if (attribute.name.toString() ==
                     AppcastConstants.AttributeURL) {
                   fileURL = attribute.value;
+                } else if (attribute.name.toString() ==
+                    AppcastConstants.AttributeEDSignature) {
+                  edSignature = attribute.value;
                 }
               });
             } else if (name == AppcastConstants.ElementMaximumSystemVersion) {
@@ -224,6 +228,7 @@ class Appcast {
           releaseNotesURL: releaseNotesLink,
           tags: tags,
           fileURL: fileURL,
+          edSignature: edSignature,
           versionString: newVersion,
         );
         localItems.add(item);
@@ -247,6 +252,7 @@ class AppcastItem {
   final String? maximumSystemVersion;
   final String? minimumUpdateVersion;
   final String? fileURL;
+  final String? edSignature;
   final int? contentLength;
   final String? versionString;
   final String? osString;
@@ -263,6 +269,7 @@ class AppcastItem {
     this.maximumSystemVersion,
     this.minimumUpdateVersion,
     this.fileURL,
+    this.edSignature,
     this.contentLength,
     this.versionString,
     this.osString,

--- a/lib/src/upgrade_store_controller.dart
+++ b/lib/src/upgrade_store_controller.dart
@@ -165,6 +165,11 @@ class UpgraderAppcastStore extends UpgraderStore {
 
   AppcastItem? _bestItem;
 
+  /// The best matching appcast item from the most recent [getVersionInfo] call.
+  ///
+  /// This value is intended to be read only after awaiting [getVersionInfo].
+  /// It is `null` before any lookup has completed or when no suitable appcast
+  /// item is found for the current version check.
   AppcastItem? get bestItem => _bestItem;
 
   @override

--- a/lib/src/upgrade_store_controller.dart
+++ b/lib/src/upgrade_store_controller.dart
@@ -163,6 +163,8 @@ class UpgraderAppcastStore extends UpgraderStore {
   /// When `null` or unparseable, defaults to `Version(0, 0, 0)`.
   final String? osVersion;
 
+  AppcastItem? bestItem;
+
   @override
   Future<UpgraderVersionInfo> getVersionInfo(
       {required UpgraderState state,
@@ -206,6 +208,8 @@ class UpgraderAppcastStore extends UpgraderStore {
     if (bestItem != null &&
         bestItem.versionString != null &&
         bestItem.versionString!.isNotEmpty) {
+      this.bestItem = bestItem;
+
       if (state.debugLogging) {
         print('upgrader: UpgraderAppcastStore best item version: '
             '${bestItem.versionString}');

--- a/lib/src/upgrade_store_controller.dart
+++ b/lib/src/upgrade_store_controller.dart
@@ -163,7 +163,9 @@ class UpgraderAppcastStore extends UpgraderStore {
   /// When `null` or unparseable, defaults to `Version(0, 0, 0)`.
   final String? osVersion;
 
-  AppcastItem? bestItem;
+  AppcastItem? _bestItem;
+
+  AppcastItem? get bestItem => _bestItem;
 
   @override
   Future<UpgraderVersionInfo> getVersionInfo(
@@ -204,11 +206,12 @@ class UpgraderAppcastStore extends UpgraderStore {
     final criticalUpdateItem = localAppcast.bestCriticalItem();
     final criticalVersion = criticalUpdateItem?.versionString ?? '';
 
+    _bestItem = null;
     final bestItem = localAppcast.bestItem();
     if (bestItem != null &&
         bestItem.versionString != null &&
         bestItem.versionString!.isNotEmpty) {
-      this.bestItem = bestItem;
+      _bestItem = bestItem;
 
       if (state.debugLogging) {
         print('upgrader: UpgraderAppcastStore best item version: '

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -283,7 +283,7 @@ void main() {
 }
 
 void validateItems(List<AppcastItem> items, Appcast appcast) {
-  expect(items.length, equals(5));
+  expect(items.length, equals(6));
 
   expect(items[0].title, equals('Version 2.0'));
   expect(items[0].itemDescription, equals('desc Версия'));
@@ -363,6 +363,18 @@ void validateItems(List<AppcastItem> items, Appcast appcast) {
   expect(items[4].minimumUpdateVersion, equals('1.9.0'));
   expect(items[4].versionString, equals('6.0.0'));
   expect(items[4].osString, isNull);
+
+  expect(items[5].title, equals('Version 7.0'));
+  expect(items[5].itemDescription, isNull);
+  expect(items[5].dateString, isNull);
+  expect(items[5].fileURL, equals('http://localhost:1337/Sparkle_Test_App.zip'));
+  expect(items[5].edSignature, equals('ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg=='));
+  expect(items[5].isCriticalUpdate, equals(false));
+  expect(items[5].maximumSystemVersion, isNull);
+  expect(items[5].minimumSystemVersion, isNull);
+  expect(items[5].minimumUpdateVersion, isNull);
+  expect(items[5].versionString, equals('7.0.0'));
+  expect(items[5].osString, 'iOS');
 
   final bestItem = appcast.bestItem()!;
   expect(bestItem, isNotNull);

--- a/test/appcast_test.dart
+++ b/test/appcast_test.dart
@@ -374,7 +374,7 @@ void validateItems(List<AppcastItem> items, Appcast appcast) {
   expect(items[5].minimumSystemVersion, isNull);
   expect(items[5].minimumUpdateVersion, isNull);
   expect(items[5].versionString, equals('7.0.0'));
-  expect(items[5].osString, 'iOS');
+  expect(items[5].osString, equals('iOS'));
 
   final bestItem = appcast.bestItem()!;
   expect(bestItem, isNotNull);

--- a/test/testappcast.xml
+++ b/test/testappcast.xml
@@ -50,5 +50,11 @@
         <sparkle:version>6.0.0</sparkle:version>
         <sparkle:minimumUpdateVersion>1.9.0</sparkle:minimumUpdateVersion>
     </item>
+    <!-- A release with edSignature -->
+    <item>
+        <title>Version 7.0</title>
+        <sparkle:version>7.0.0</sparkle:version>
+        <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" sparkle:version="4.0" sparkle:os="iOS" />
+    </item>
   </channel>
 </rss>

--- a/test/upgrader_store_controller_test.dart
+++ b/test/upgrader_store_controller_test.dart
@@ -172,7 +172,10 @@ void main() {
     final fakeAppcast = FakeAppcast();
 
     final upgraderAppcastStore = UpgraderAppcastStore(
-        appcastURL: appcastURL, appcast: fakeAppcast, osVersion: '0.0.0');
+      appcastURL: appcastURL,
+      appcast: fakeAppcast,
+      osVersion: '0.0.0',
+    );
 
     // Act
     await upgraderAppcastStore.getVersionInfo(

--- a/test/upgrader_store_controller_test.dart
+++ b/test/upgrader_store_controller_test.dart
@@ -153,4 +153,36 @@ void main() {
     expect(versionInfo.isCriticalUpdate, isNull);
     expect(versionInfo.releaseNotes, isNull);
   });
+
+  test('UpgraderAppcastStore has bestItem after getVersionInfo', () async {
+    final installedVersion = Version.parse('1.9.6');
+    final state = UpgraderState(
+      debugLogging: true,
+      client: await MockPlayStoreSearchClient.setupMockClient(),
+      packageInfo: PackageInfo(
+        appName: 'Upgrader',
+        packageName: 'com.kotoko.express',
+        version: installedVersion.toString(),
+        buildNumber: '42',
+      ),
+      upgraderOS: MockUpgraderOS(android: true),
+    );
+
+    const appcastURL = 'https://sparkle-project.org/test/testappcast.xml';
+    final fakeAppcast = FakeAppcast();
+
+    final upgraderAppcastStore = UpgraderAppcastStore(
+        appcastURL: appcastURL, appcast: fakeAppcast, osVersion: '0.0.0');
+
+    // Act
+    await upgraderAppcastStore.getVersionInfo(
+      state: state,
+      installedVersion: installedVersion,
+      country: 'US',
+      language: 'en',
+    );
+
+    // Assert
+    expect(upgraderAppcastStore.bestItem, isNotNull);
+  });
 }


### PR DESCRIPTION
This PR adds parsing of the sparkle:edSignature from AppcastItem enclosures which is a Sparkle-standard element that wasn't parsed by the upgrader package yet. It also makes the selected bestItem of the UpgraderAppcastStore accessible from the outside. With these changes the package can be used Windows and macOS Apps to download the update in the onUpdate callback of UpgradeAlert and then check it signature before executing to confirm its authenticity.

Example usage of an App using this version of the package:

```xml
<item>
    <title>Version 7.0</title>
    <sparkle:version>7.0.0</sparkle:version>
    <enclosure url="http://localhost:1337/Sparkle_Test_App.zip" sparkle:edSignature="ify59pDIuduaZcLnLvQjGqNQIAqi4dVgeA3L/e7I7xaqn9pVdiVZH7Na3v+Gp4ElAKJfX4Pfq8cgElfXmZc4Cg==" sparkle:version="4.0" sparkle:os="iOS" />
</item>
```

```dart
UpgradeAlert(
  ...
  onUpdate: () {
    final AppcastItem? item = _appcastStore.bestItem;

    if (item == null || item.fileURL == null || item.edSignature == null) {
        // handle error case
    }
  
    downloadUpdateAndExecute(appcastStore.bestItem!.fileURL!, appcastStore.bestItem!.edSignature!);
  
    return false;
  },
)
```