### PR TITLE
Fix iOS upgrade popup reappearing after update due to build metadata in version string (fixes: #480)

### DIFF
--- a/lib/src/appcast.dart
+++ b/lib/src/appcast.dart
@@ -62,8 +62,10 @@ class Appcast {
           bestItem = item;
         } else {
           try {
-            final itemVersion = Version.parse(item.versionString!);
-            final bestItemVersion = Version.parse(bestItem!.versionString!);
+            final itemVersion =
+                Version.parse(item.versionString!.split('+').first);
+            final bestItemVersion =
+                Version.parse(bestItem!.versionString!.split('+').first);
             if (itemVersion > bestItemVersion) {
               bestItem = item;
             }
@@ -93,8 +95,10 @@ class Appcast {
           bestItem = item;
         } else {
           try {
-            final itemVersion = Version.parse(item.versionString!);
-            final bestItemVersion = Version.parse(bestItem!.versionString!);
+            final itemVersion =
+                Version.parse(item.versionString!.split('+').first);
+            final bestItemVersion =
+                Version.parse(bestItem!.versionString!.split('+').first);
             if (itemVersion > bestItemVersion) {
               bestItem = item;
             }
@@ -301,7 +305,8 @@ class AppcastItem {
     if (supported) {
       if (maximumSystemVersion != null) {
         try {
-          final maxVersion = Version.parse(maximumSystemVersion!);
+          final maxVersion =
+              Version.parse(maximumSystemVersion!.split('+').first);
           if (osVersion > maxVersion) {
             supported = false;
           }
@@ -311,7 +316,8 @@ class AppcastItem {
       }
       if (supported && minimumSystemVersion != null) {
         try {
-          final minVersion = Version.parse(minimumSystemVersion!);
+          final minVersion =
+              Version.parse(minimumSystemVersion!.split('+').first);
           if (osVersion < minVersion) {
             supported = false;
           }
@@ -323,7 +329,8 @@ class AppcastItem {
           minimumUpdateVersion != null &&
           currentAppVersion != null) {
         try {
-          final minUpdateVersion = Version.parse(minimumUpdateVersion!);
+          final minUpdateVersion =
+              Version.parse(minimumUpdateVersion!.split('+').first);
           if (currentAppVersion < minUpdateVersion) {
             supported = false;
           }

--- a/lib/src/upgrade_store_controller.dart
+++ b/lib/src/upgrade_store_controller.dart
@@ -47,7 +47,12 @@ class UpgraderAppStore extends UpgraderStore {
       final version = iTunes.version(response);
       if (version != null) {
         try {
-          appStoreVersion = Version.parse(version);
+          final normalized = version.split('+').first;
+          if (normalized != version && state.debugLogging) {
+            print(
+                "upgrader: version normalized: '$version' → '$normalized'");
+          }
+          appStoreVersion = Version.parse(normalized);
         } catch (e) {
           if (state.debugLogging) {
             print(
@@ -105,7 +110,12 @@ class UpgraderPlayStore extends UpgraderStore {
       final version = playStore.version(response);
       if (version != null) {
         try {
-          appStoreVersion = Version.parse(version);
+          final normalized = version.split('+').first;
+          if (normalized != version && state.debugLogging) {
+            print(
+                "upgrader: version normalized: '$version' → '$normalized'");
+          }
+          appStoreVersion = Version.parse(normalized);
         } catch (e) {
           if (state.debugLogging) {
             print(
@@ -120,7 +130,7 @@ class UpgraderPlayStore extends UpgraderStore {
       final mav = playStore.minAppVersion(response);
       if (mav != null) {
         try {
-          final minVersion = mav.toString();
+          final minVersion = mav.toString().split('+').first;
           minAppVersion = Version.parse(minVersion);
 
           if (state.debugLogging) {
@@ -227,7 +237,8 @@ class UpgraderAppcastStore extends UpgraderStore {
 
       try {
         if (criticalVersion.isNotEmpty &&
-            installedVersion < Version.parse(criticalVersion)) {
+            installedVersion <
+                Version.parse(criticalVersion.split('+').first)) {
           isCriticalUpdate = true;
         }
       } catch (e) {
@@ -239,7 +250,12 @@ class UpgraderAppcastStore extends UpgraderStore {
 
       if (bestItem.versionString != null) {
         try {
-          appStoreVersion = Version.parse(bestItem.versionString!);
+          final normalized = bestItem.versionString!.split('+').first;
+          if (normalized != bestItem.versionString && state.debugLogging) {
+            print(
+                "upgrader: version normalized: '${bestItem.versionString}' → '$normalized'");
+          }
+          appStoreVersion = Version.parse(normalized);
         } catch (e) {
           if (state.debugLogging) {
             print(

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -262,13 +262,9 @@ class Upgrader with WidgetsBindingObserver {
     }
 
     // Determine the installed version of this app.
-    late Version installedVersion;
-    try {
-      installedVersion = Version.parse(state.packageInfo!.version);
-    } catch (e) {
-      if (state.debugLogging) {
-        print('upgrader: installedVersion exception: $e');
-      }
+    final installedVersion = parseVersion(
+        state.packageInfo!.version, 'installedVersion', state.debugLogging);
+    if (installedVersion == null) {
       updateState(state.copyWithNull(versionInfo: null));
       return null;
     }
@@ -370,13 +366,10 @@ class Upgrader with WidgetsBindingObserver {
     var rv = false;
     final minVersion = state.minAppVersion ?? versionInfo?.minAppVersion;
     if (minVersion != null && state.packageInfo != null) {
-      try {
-        final installedVersion = Version.parse(state.packageInfo!.version);
+      final installedVersion = parseVersion(
+          state.packageInfo!.version, 'installedVersion', state.debugLogging);
+      if (installedVersion != null) {
         rv = installedVersion < minVersion;
-      } catch (e) {
-        if (state.debugLogging) {
-          print(e);
-        }
       }
     }
     return rv;
@@ -424,10 +417,12 @@ class Upgrader with WidgetsBindingObserver {
     }
 
     try {
-      final installedVersion = Version.parse(state.packageInfo!.version);
-
-      final available = versionInfo!.appStoreVersion! > installedVersion;
-      _updateAvailable = available ? versionInfo?.appStoreVersion : null;
+      final installedVersion = parseVersion(
+          state.packageInfo!.version, 'installedVersion', state.debugLogging);
+      if (installedVersion != null) {
+        final available = versionInfo!.appStoreVersion! > installedVersion;
+        _updateAvailable = available ? versionInfo?.appStoreVersion : null;
+      }
     } on Exception catch (e) {
       if (state.debugLogging) {
         print('upgrader: isUpdateAvailable: $e');
@@ -527,23 +522,13 @@ class Upgrader with WidgetsBindingObserver {
     }
     final versionAlerted = prefs.getString('lastVersionAlerted');
     if (versionAlerted != null) {
-      try {
-        _lastVersionAlerted = Version.parse(versionAlerted);
-      } catch (e) {
-        if (state.debugLogging) {
-          print('upgrader: lastVersionAlerted exception: $e');
-        }
-      }
+      _lastVersionAlerted = parseVersion(
+          versionAlerted, 'lastVersionAlerted', state.debugLogging);
     }
     final ignoredVersion = prefs.getString('userIgnoredVersion');
     if (ignoredVersion != null) {
-      try {
-        _userIgnoredVersion = Version.parse(ignoredVersion);
-      } catch (e) {
-        if (state.debugLogging) {
-          print('upgrader: userIgnoredVersion exception: $e');
-        }
-      }
+      _userIgnoredVersion =
+          parseVersion(ignoredVersion, 'userIgnoredVersion', state.debugLogging);
     }
 
     return true;
@@ -581,11 +566,13 @@ class Upgrader with WidgetsBindingObserver {
       String? version, String name, bool debugLogging) {
     if (version == null) return null;
     try {
-      return Version.parse(version);
+      final normalized = version.split('+').first;
+      if (normalized != version && debugLogging) {
+        print("upgrader: version normalized: '$version' → '$normalized'");
+      }
+      return Version.parse(normalized);
     } catch (e) {
-      // if (state.debugLogging) {
       print('upgrader: _parseVersion $name exception: $e');
-      // }
       return null;
     }
   }

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -1375,6 +1375,75 @@ void main() {
     verifyMessages(UpgraderMessages(code: 'vi'), 'vi');
     verifyMessages(UpgraderMessages(code: 'zh'), 'zh');
   }, skip: false);
+
+  test('parseVersion strips build metadata from version string', () {
+    final result = Upgrader.parseVersion('1.2.3+45', 'test', false);
+    expect(result, isNotNull);
+    expect(result, equals(Version.parse('1.2.3')));
+    expect(result! > Version.parse('1.2.3'), isFalse);
+  });
+
+  test('parseVersion leaves clean version string unchanged', () {
+    final result = Upgrader.parseVersion('1.2.3', 'test', false);
+    expect(result, isNotNull);
+    expect(result, equals(Version.parse('1.2.3')));
+  });
+
+  testWidgets(
+      'isUpdateAvailable returns false when installed version has build metadata matching store version',
+      (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      final client = MockITunesSearchClient.setupMockClient();
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+              appName: 'Upgrader',
+              packageName: 'com.larryaasen.upgrader',
+              version: '1.2.3+45',
+              buildNumber: '45'));
+
+      expect(await upgrader.initialize(), isTrue);
+
+      upgrader.updateState(upgrader.state.copyWith(
+          versionInfo: UpgraderVersionInfo(
+              appStoreVersion: Version.parse('1.2.3'))));
+
+      expect(upgrader.isUpdateAvailable(), isFalse);
+    });
+  });
+
+  testWidgets(
+      'isUpdateAvailable returns true when installed version with build metadata is genuinely older',
+      (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      final client = MockITunesSearchClient.setupMockClient();
+      final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: client,
+        debugLogging: true,
+      );
+
+      upgrader.installPackageInfo(
+          packageInfo: PackageInfo(
+              appName: 'Upgrader',
+              packageName: 'com.larryaasen.upgrader',
+              version: '1.2.2+99',
+              buildNumber: '99'));
+
+      expect(await upgrader.initialize(), isTrue);
+
+      upgrader.updateState(upgrader.state.copyWith(
+          versionInfo: UpgraderVersionInfo(
+              appStoreVersion: Version.parse('1.2.3'))));
+
+      expect(upgrader.isUpdateAvailable(), isTrue);
+    });
+  });
 }
 
 void verifyMessages(UpgraderMessages messages, String code) {


### PR DESCRIPTION
@larryaasen, thanks for maintaining this package! Here's a fix for the false-positive upgrade prompt reported in #480.
        
Fixes #480

## Problem

On iOS, the upgrade popup reappears even after the user has already updated to the latest version available in the App Store.

**Root cause:** Flutter's `PackageInfo.version` can return a version string that includes build metadata (e.g. `1.2.3+45`), while the iTunes Search API always returns a clean semantic version (`1.2.3`). Because `Version.parse('1.2.3+45')` produces a value that compares as greater than `Version.parse('1.2.3')`, the library incorrectly treats the installed version as newer — or fails to recognise that the versions are equal — resulting in a false "update available" state.

## Solution

Normalize version strings by stripping the `+<build>` suffix before parsing, so `1.2.3+45` and `1.2.3` are treated as semantically equal.

The fix is applied in `Upgrader.parseVersion()` — the central parsing utility — so all call sites that already route through it benefit automatically. Direct `Version.parse()` call sites in `upgrader.dart` have been migrated to use `parseVersion()`. Call sites in `upgrade_store_controller.dart` and `appcast.dart` (which cannot import `Upgrader` without a circular dependency) apply the same `version.split('+').first` normalization inline.

A debug log line is emitted whenever normalization occurs:

```
upgrader: version normalized: '1.2.3+45' → '1.2.3'
```

## Changes

- `lib/src/upgrader.dart` — updated `parseVersion()` to strip build metadata; migrated all direct `Version.parse()` call sites
- `lib/src/upgrade_store_controller.dart` — normalized store-supplied version strings in `UpgraderAppStore`, `UpgraderPlayStore`, and `UpgraderAppcastStore`
- `lib/src/appcast.dart` — normalized version strings used in best-item selection and host-support checks

## Tests

Added 4 tests in `test/upgrader_test.dart`:

| Test | Expected |
|---|---|
| `parseVersion('1.2.3+45')` | equals `Version.parse('1.2.3')`, not greater |
| `parseVersion('1.2.3')` | unchanged, no regression |
| Installed `1.2.3+45`, store `1.2.3` | `isUpdateAvailable()` → `false` |
| Installed `1.2.2+99`, store `1.2.3` | `isUpdateAvailable()` → `true` |

Full test suite passes: `flutter test --coverage`.

## Notes

- No public API changes.
- The `package:version` library's behaviour with build metadata may vary; stripping it before parsing is the safest approach regardless of library internals.
- Play Store and Appcast paths receive the same normalization for consistency, though the primary motivation is the iOS/App Store case.
