### PR TITLE
Fixed `barrierDismissible` being ignored in UpgradeAlert (#457)

### DIFF
--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -283,7 +283,7 @@ class UpgradeAlertState extends State<UpgradeAlert> {
   }
 
   /// Determines if the dialog blocks the current route from being popped.
-  /// Will return the result from [shouldPopScope] if it is not null, otherwise it will return [widget.barrierDismissible].
+  /// Will return the result from [shouldPopScope] if it is not null, otherwise it will return [UpgradeAlert.barrierDismissible].
   bool onCanPop() {
     if (widget.upgrader.state.debugLogging) {
       print('upgrader: onCanPop called');

--- a/lib/src/upgrade_alert.dart
+++ b/lib/src/upgrade_alert.dart
@@ -283,7 +283,7 @@ class UpgradeAlertState extends State<UpgradeAlert> {
   }
 
   /// Determines if the dialog blocks the current route from being popped.
-  /// Will return the result from [shouldPopScope] if it is not null, otherwise it will return false.
+  /// Will return the result from [shouldPopScope] if it is not null, otherwise it will return [widget.barrierDismissible].
   bool onCanPop() {
     if (widget.upgrader.state.debugLogging) {
       print('upgrader: onCanPop called');
@@ -296,7 +296,7 @@ class UpgradeAlertState extends State<UpgradeAlert> {
       return should;
     }
 
-    return false;
+    return widget.barrierDismissible;
   }
 
   Widget alertDialog(

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -659,6 +659,122 @@ void main() {
     expect(called, true);
   });
 
+  testWidgets('onCanPop returns true when barrierDismissible true and shouldPopScope not set',
+      (WidgetTester tester) async {
+    final client = MockITunesSearchClient.setupMockClient();
+    final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true), client: client);
+
+    upgrader.installPackageInfo(
+        packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '5.6.0',
+            buildNumber: '400'));
+    upgrader.initialize().then((value) {});
+    await tester.pumpAndSettle();
+
+    final upgradeAlert = wrapper(
+      UpgradeAlert(
+        upgrader: upgrader,
+        barrierDismissible: true,
+        child: const Center(child: Text('Upgrading')),
+      ),
+    );
+    await tester.pumpWidget(upgradeAlert);
+    await tester.pumpAndSettle();
+
+    final state = tester.state<UpgradeAlertState>(find.byType(UpgradeAlert));
+    expect(state.onCanPop(), true);
+  });
+
+  testWidgets('onCanPop returns false when barrierDismissible false and shouldPopScope not set',
+      (WidgetTester tester) async {
+    final client = MockITunesSearchClient.setupMockClient();
+    final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true), client: client);
+
+    upgrader.installPackageInfo(
+        packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '5.6.0',
+            buildNumber: '400'));
+    upgrader.initialize().then((value) {});
+    await tester.pumpAndSettle();
+
+    final upgradeAlert = wrapper(
+      UpgradeAlert(
+        upgrader: upgrader,
+        child: const Center(child: Text('Upgrading')),
+      ),
+    );
+    await tester.pumpWidget(upgradeAlert);
+    await tester.pumpAndSettle();
+
+    final state = tester.state<UpgradeAlertState>(find.byType(UpgradeAlert));
+    expect(state.onCanPop(), false);
+  });
+
+  testWidgets('onCanPop returns false when barrierDismissible true but shouldPopScope returns false',
+      (WidgetTester tester) async {
+    final client = MockITunesSearchClient.setupMockClient();
+    final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true), client: client);
+
+    upgrader.installPackageInfo(
+        packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '5.6.0',
+            buildNumber: '400'));
+    upgrader.initialize().then((value) {});
+    await tester.pumpAndSettle();
+
+    final upgradeAlert = wrapper(
+      UpgradeAlert(
+        upgrader: upgrader,
+        barrierDismissible: true,
+        shouldPopScope: () => false,
+        child: const Center(child: Text('Upgrading')),
+      ),
+    );
+    await tester.pumpWidget(upgradeAlert);
+    await tester.pumpAndSettle();
+
+    final state = tester.state<UpgradeAlertState>(find.byType(UpgradeAlert));
+    expect(state.onCanPop(), false);
+  });
+
+  testWidgets('onCanPop returns true when barrierDismissible false but shouldPopScope returns true',
+      (WidgetTester tester) async {
+    final client = MockITunesSearchClient.setupMockClient();
+    final upgrader = Upgrader(
+        upgraderOS: MockUpgraderOS(ios: true), client: client);
+
+    upgrader.installPackageInfo(
+        packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '5.6.0',
+            buildNumber: '400'));
+    upgrader.initialize().then((value) {});
+    await tester.pumpAndSettle();
+
+    final upgradeAlert = wrapper(
+      UpgradeAlert(
+        upgrader: upgrader,
+        shouldPopScope: () => true,
+        child: const Center(child: Text('Upgrading')),
+      ),
+    );
+    await tester.pumpWidget(upgradeAlert);
+    await tester.pumpAndSettle();
+
+    final state = tester.state<UpgradeAlertState>(find.byType(UpgradeAlert));
+    expect(state.onCanPop(), true);
+  });
+
   testWidgets('test UpgradeAlert no update', (WidgetTester tester) async {
     expect(Upgrader.sharedInstance.isTooSoon(), false);
 


### PR DESCRIPTION
Fixes #457

Hi @larryaasen,
Following up on our previous interaction (#552), I brought a new PR for a different issue. Taking your previous feedback to heart, I’ve thoroughly verified the root cause with historical context and reproducible code before submitting.

### Problem

Setting `barrierDismissible: true` on `UpgradeAlert` had no effect — tapping outside the dialog never dismissed it, even though that is the documented and expected behavior of the parameter.

### Verification

https://github.com/user-attachments/assets/7283df01-02b2-4b98-b0bf-3133ab0231fd



| `barrierDismissible: true` | `barrierDismissible: false` |
|---|---|
| Tap outside → dialog **closes** ✅ | Tap outside → dialog **stays** ✅ |

<details>
<summary>Verification demo — <code>example/lib/main_barrier_dismissible.dart</code> (not included in this PR)</summary>

```dart
// Copyright (c) 2024 Larry Aasen. All rights reserved.
//
// Demonstrates the barrierDismissible fix (Issue #457).
//
// Before the fix: barrierDismissible: true was ignored — tapping outside
// the dialog had no effect because PopScope always returned canPop: false.
//
// After the fix: barrierDismissible: true works as expected — tapping
// outside the dialog dismisses it.
//
// How to use this demo:
//   1. Tap "barrierDismissible: true"  → dialog appears → tap outside → dialog closes   ✓
//   2. Tap "barrierDismissible: false" → dialog appears → tap outside → dialog stays    ✓

import 'package:flutter/material.dart';
import 'package:upgrader/upgrader.dart';

void main() async {
  WidgetsFlutterBinding.ensureInitialized();
  await Upgrader.clearSavedSettings();
  runApp(const MyApp());
}

class MyApp extends StatelessWidget {
  const MyApp({super.key});

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      title: 'barrierDismissible Demo',
      routes: {
        '/dismissible': (_) => _DemoPage(barrierDismissible: true),
        '/non-dismissible': (_) => _DemoPage(barrierDismissible: false),
      },
      home: const _HomePage(),
    );
  }
}

class _HomePage extends StatelessWidget {
  const _HomePage();

  @override
  Widget build(BuildContext context) {
    return Scaffold(
      appBar: AppBar(title: const Text('barrierDismissible Demo')),
      body: Center(
        child: Column(
          mainAxisSize: MainAxisSize.min,
          children: [
            const Text(
              'Tap a button, then tap OUTSIDE the dialog.',
              textAlign: TextAlign.center,
            ),
            const SizedBox(height: 32),
            ElevatedButton(
              onPressed: () => Navigator.pushNamed(context, '/dismissible'),
              child: const Text('barrierDismissible: true\n→ tap outside closes dialog',
                  textAlign: TextAlign.center),
            ),
            const SizedBox(height: 16),
            ElevatedButton(
              onPressed: () => Navigator.pushNamed(context, '/non-dismissible'),
              child: const Text('barrierDismissible: false\n→ tap outside does nothing',
                  textAlign: TextAlign.center),
            ),
          ],
        ),
      ),
    );
  }
}

class _DemoPage extends StatelessWidget {
  final bool barrierDismissible;

  _DemoPage({required this.barrierDismissible})
      : _upgrader = Upgrader(debugDisplayAlways: true, debugLogging: true);

  final Upgrader _upgrader;

  @override
  Widget build(BuildContext context) {
    return UpgradeAlert(
      upgrader: _upgrader,
      barrierDismissible: barrierDismissible,
      child: Scaffold(
        appBar: AppBar(
          title: Text('barrierDismissible: $barrierDismissible'),
        ),
        body: Center(
          child: Text(
            barrierDismissible
                ? 'Dialog should close when you tap outside.'
                : 'Dialog should stay when you tap outside.',
            textAlign: TextAlign.center,
          ),
        ),
      ),
    );
  }
}
```

Save the code above as `example/lib/main_barrier_dismissible.dart` in a local checkout, then run:  
```bash
flutter run -t example/lib/main_barrier_dismissible.dart
```

</details>

### Root Cause Investigation

A `git blame` trace on `upgrade_alert.dart` revealed the bug predates the `WillPopScope` → `PopScope` migration (commit `4cbc70d`, 2024-02-24). The original `onWillPop()` always returned `false` when `shouldPopScope` was not provided, and this was carried over verbatim when `PopScope` was introduced:

<details>
<summary>History of the bug across both APIs</summary>

```dart
// Before migration (WillPopScope era)
bool onWillPop() {
  if (widget.shouldPopScope != null) return widget.shouldPopScope!();
  return false;  // ← bug origin
}

// After migration (PopScope era) — same bug, different method name
bool onCanPop() {
  if (widget.shouldPopScope != null) return widget.shouldPopScope!();
  return false;  // ← bug carried over unchanged
}
```

</details>

Flutter's `PopScope.canPop` controls both barrier taps and the system back button via `Navigator.maybePop()`. Because `canPop` was hardcoded to `false`, the dialog's `barrierDismissible: true` setting was immediately overridden — the barrier let the tap through, but `PopScope` blocked the resulting pop:

```
showDialog(barrierDismissible: true)
    └─ barrier tap → Navigator.maybePop() → pop attempt
           └─ PopScope(canPop: false) → blocks pop → dialog stays open  ✗
```

The parameter `barrierDismissible` existed in the public API throughout this period, but its value was never actually consulted in the pop-scope logic. The bug was invisible at code-review time because the rename from `canDismissDialog` to `barrierDismissible` happened separately and no one connected the two.

### Fix

A one-line change in `onCanPop()`: fall back to `widget.barrierDismissible` instead of `false` when `shouldPopScope` is not set.

<details>
<summary>lib/src/upgrade_alert.dart</summary>

```dart
// Before
bool onCanPop() {
  if (widget.shouldPopScope != null) return widget.shouldPopScope!();
  return false;
}

// After
bool onCanPop() {
  if (widget.shouldPopScope != null) return widget.shouldPopScope!();
  return widget.barrierDismissible;
}
```

</details>

**Backward compatibility:** `barrierDismissible` defaults to `false`, so existing code that never set the parameter is unaffected.

**`shouldPopScope` priority is preserved:** When `shouldPopScope` is provided, it continues to take precedence over `barrierDismissible`. Fine-grained control (e.g. allowing barrier taps but blocking the hardware back button) is still achievable via `shouldPopScope`.

**Side effect to be aware of:** Because `PopScope.canPop` controls both barrier taps and the system back button uniformly, setting `barrierDismissible: true` will also allow the hardware back button to dismiss the dialog. If you need barrier-only dismissal, use `shouldPopScope` to express that intent explicitly.

### Tests Added

Four widget tests were added to `upgrader_test.dart` to lock in the corrected behavior and prevent regression:

| Scenario | `barrierDismissible` | `shouldPopScope` | Expected `onCanPop()` |
|---|---|---|---|
| Bug fix (was broken) | `true` | not set | `true` |
| Default behavior | `false` | not set | `false` |
| `shouldPopScope` overrides `true` | `true` | `() => false` | `false` |
| `shouldPopScope` overrides `false` | `false` | `() => true` | `true` |

<details>
<summary>test/upgrader_test.dart — new tests</summary>

```dart
testWidgets('onCanPop returns true when barrierDismissible true and shouldPopScope not set',
    (WidgetTester tester) async {
  final client = MockITunesSearchClient.setupMockClient();
  final upgrader = Upgrader(upgraderOS: MockUpgraderOS(ios: true), client: client);
  upgrader.installPackageInfo(
      packageInfo: PackageInfo(
          appName: 'Upgrader',
          packageName: 'com.larryaasen.upgrader',
          version: '5.6.0',
          buildNumber: '400'));
  upgrader.initialize().then((value) {});
  await tester.pumpAndSettle();

  await tester.pumpWidget(wrapper(UpgradeAlert(
    upgrader: upgrader,
    barrierDismissible: true,
    child: const Center(child: Text('Upgrading')),
  )));
  await tester.pumpAndSettle();

  final state = tester.state<UpgradeAlertState>(find.byType(UpgradeAlert));
  expect(state.onCanPop(), true);
});

testWidgets('onCanPop returns false when barrierDismissible false and shouldPopScope not set', ...);
testWidgets('onCanPop returns false when barrierDismissible true but shouldPopScope returns false', ...);
testWidgets('onCanPop returns true when barrierDismissible false but shouldPopScope returns true', ...);
```

> **Note:** installed version is set to `5.6.0` (matching the mock store version) so `shouldDisplayUpgrade()` returns `false` and no `Future.delayed` timer is created, allowing `pumpAndSettle()` to complete without hanging.

</details>

All 39 tests pass. `flutter analyze` reports no issues.



