### PR TITLE
[517] Add checkOnResume to stop the version check on app resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.6.0
+
+- [517] Added the `checkOnResume` parameter to `Upgrader` that, when `false`, stops the store version check from being made each time the app is resumed from the background.
+
 ## 13.5.0
 
 - Updated the xml dependency constraint from `^6.3.0` to `>=6.3.0 <8.0.0` to support stable xml 7.0.0.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Here are the custom parameters for `UpgradeCard`:
 
 The `Upgrader` class can be customized by setting parameters in the constructor, and passing it
 
+* checkOnResume: check the store for a new version each time the app is resumed from the background, which defaults to ```true```. Set to ```false``` to only check when `upgrader` is initialized, which avoids a network request on every resume.
 * client: an HTTP Client that can be replaced for mock testing, defaults to `http.Client()`.
 * clientHeaders: Provide the HTTP headers used by `client`, which defaults to ```null```
 * countryCode: the country code that will override the system locale, which defaults to ```null```

--- a/lib/src/upgrade_state.dart
+++ b/lib/src/upgrade_state.dart
@@ -13,6 +13,7 @@ class UpgraderState {
   /// Creates an [Upgrader] state.
   UpgraderState({
     required this.client,
+    this.checkOnResume = true,
     this.clientHeaders,
     this.countryCodeOverride,
     this.debugDisplayAlways = false,
@@ -27,6 +28,12 @@ class UpgraderState {
     required this.upgraderOS,
     this.versionInfo,
   });
+
+  /// When `true`, the latest version info is retrieved from the store each
+  /// time the app is resumed from the background. When `false`, the version
+  /// info is only retrieved when [Upgrader] is initialized, or when
+  /// [Upgrader.updateVersionInfo] is called directly.
+  final bool checkOnResume;
 
   /// Provide an HTTP Client that can be replaced during testing.
   final http.Client client;
@@ -78,6 +85,7 @@ class UpgraderState {
 
   /// Creates a new state object by copying existing data and modifying selected fields.
   UpgraderState copyWith({
+    bool? checkOnResume,
     http.Client? client,
     Map<String, String>? clientHeaders,
     String? countryCodeOverride,
@@ -94,6 +102,7 @@ class UpgraderState {
     UpgraderVersionInfo? versionInfo,
   }) {
     return UpgraderState(
+      checkOnResume: checkOnResume ?? this.checkOnResume,
       client: client ?? this.client,
       clientHeaders: clientHeaders ?? this.clientHeaders,
       countryCodeOverride: countryCodeOverride ?? this.countryCodeOverride,
@@ -124,6 +133,7 @@ class UpgraderState {
     bool? versionInfo,
   }) {
     return UpgraderState(
+      checkOnResume: checkOnResume,
       client: client,
       clientHeaders: clientHeaders,
       countryCodeOverride:

--- a/lib/src/upgrader.dart
+++ b/lib/src/upgrader.dart
@@ -49,6 +49,10 @@ class Upgrader with WidgetsBindingObserver {
   /// trigger an alert or other UI to evaluate upgrading criteria.
   ///
   /// Parameters:
+  /// - [checkOnResume]: When `true`, the version info is retrieved from the
+  ///   store each time the app is resumed from the background. When `false`,
+  ///   the version info is only retrieved during [initialize], which means no
+  ///   network requests are made when the app is resumed. Defaults to `true`.
   /// - [client]: An HTTP client used to retrieve version information from the
   ///   store. Defaults to `http.Client()`. Can be replaced for mock testing.
   /// - [clientHeaders]: Optional HTTP headers used by [client]. Defaults to `null`.
@@ -80,6 +84,7 @@ class Upgrader with WidgetsBindingObserver {
   /// - [willDisplayUpgrade]: An optional callback invoked each time [Upgrader]
   ///   determines whether to show or hide the upgrade prompt. Defaults to `null`.
   Upgrader({
+    bool checkOnResume = true,
     http.Client? client,
     Map<String, String>? clientHeaders,
     String? countryCode,
@@ -95,6 +100,7 @@ class Upgrader with WidgetsBindingObserver {
     UpgraderOS? upgraderOS,
     this.willDisplayUpgrade,
   })  : _state = UpgraderState(
+          checkOnResume: checkOnResume,
           client: client ?? http.Client(),
           clientHeaders: clientHeaders,
           countryCodeOverride: countryCode,
@@ -196,7 +202,8 @@ class Upgrader with WidgetsBindingObserver {
       await updateVersionInfo();
 
       // Add an observer of application events, so that when the app returns
-      // from the background, the version info is updated.
+      // from the background, the version info is updated when [checkOnResume]
+      // is true.
       WidgetsBinding.instance.addObserver(this);
 
       return true;
@@ -239,6 +246,12 @@ class Upgrader with WidgetsBindingObserver {
 
     // When app has resumed from background.
     if (lifecycleState == AppLifecycleState.resumed) {
+      if (!state.checkOnResume) {
+        if (state.debugLogging) {
+          print('upgrader: checkOnResume is false, not updating version info');
+        }
+        return;
+      }
       await updateVersionInfo();
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upgrader
 description: Flutter package for prompting users to upgrade when there is a newer version of the app in the store.
-version: 13.5.0
+version: 13.6.0
 homepage: https://github.com/larryaasen/upgrader
 
 environment:

--- a/test/upgrader_test.dart
+++ b/test/upgrader_test.dart
@@ -6,7 +6,9 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
+import 'package:http/http.dart' as http;
 import 'package:http/src/client.dart';
+import 'package:http/testing.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:upgrader/upgrader.dart';
@@ -1249,6 +1251,72 @@ void main() {
 
       // Installed version 2.0.0 < minAppVersion 3.0.0 — should display.
       expect(upgrader.belowMinAppVersion(), isTrue);
+      expect(upgrader.shouldDisplayUpgrade(), isTrue);
+    }, skip: false);
+
+    test('checkOnResume defaults to true and updates on resume', () async {
+      var requestCount = 0;
+      final upgrader = Upgrader(
+        debugLogging: true,
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: MockClient((request) async {
+          requestCount++;
+          return http.Response(
+              '{"results": [{"version": "5.6", "bundleId": "com.larryaasen.upgrader"}]}',
+              200);
+        }),
+      )..installPackageInfo(
+          packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '2.0.0',
+            buildNumber: '42',
+          ),
+        );
+
+      expect(upgrader.state.checkOnResume, isTrue);
+
+      await upgrader.initialize();
+      final countAfterInit = requestCount;
+
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(requestCount, countAfterInit + 1);
+    }, skip: false);
+
+    test('checkOnResume false does not update on resume', () async {
+      var requestCount = 0;
+      final upgrader = Upgrader(
+        checkOnResume: false,
+        debugLogging: true,
+        upgraderOS: MockUpgraderOS(ios: true),
+        client: MockClient((request) async {
+          requestCount++;
+          return http.Response(
+              '{"results": [{"version": "5.6", "bundleId": "com.larryaasen.upgrader"}]}',
+              200);
+        }),
+      )..installPackageInfo(
+          packageInfo: PackageInfo(
+            appName: 'Upgrader',
+            packageName: 'com.larryaasen.upgrader',
+            version: '2.0.0',
+            buildNumber: '42',
+          ),
+        );
+
+      expect(upgrader.state.checkOnResume, isFalse);
+
+      await upgrader.initialize();
+      final countAfterInit = requestCount;
+
+      // Resuming from the background makes no additional network request, and
+      // the version info from initialize() is still available.
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.paused);
+      await upgrader.didChangeAppLifecycleState(AppLifecycleState.resumed);
+      expect(requestCount, countAfterInit);
+
+      expect(upgrader.currentAppStoreVersion, '5.6.0');
       expect(upgrader.shouldDisplayUpgrade(), isTrue);
     }, skip: false);
 


### PR DESCRIPTION
Fixes #517.

### Problem

`Upgrader` registers itself as a `WidgetsBindingObserver` during `initialize()`, and `didChangeAppLifecycleState` unconditionally called `updateVersionInfo()` on every `AppLifecycleState.resumed` event. That means a network request to the App Store / Play Store every time the app returns from the background, with no way to turn it off.

As noted in the issue, this is unrelated to `durationUntilAlertAgain`, which only controls how often the *alert* is displayed, not how often the version info is *retrieved*. The two are now decoupled.

### Change

Added a `checkOnResume` parameter to `Upgrader`, defaulting to `true`, so existing behavior is unchanged. When `false`, the version info is only retrieved during `initialize()`, or when `updateVersionInfo()` is called directly.

```dart
Upgrader(checkOnResume: false)
```

The parameter is stored in `UpgraderState`, so it can also be changed at runtime:

```dart
upgrader.updateState(upgrader.state.copyWith(checkOnResume: false));
```

The observer is still registered in both cases; only the version check is skipped, and a debug log line is printed when `debugLogging` is enabled.

### Tests

Two tests were added using a request counting `MockClient`:

- default behavior still retrieves version info on resume
- with `checkOnResume: false`, repeated resume/pause cycles make no additional requests, while the version info from `initialize()` remains available and `shouldDisplayUpgrade()` still returns `true`

`flutter analyze` is clean and all tests pass.
